### PR TITLE
Add architecture documentation and enhance API for history retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ npm run dev:frontend
 Each Node entrypoint auto-loads `.env.local` from the repo root if it exists.
 Set `HUB_HTTP_URL` and `HUB_WS_URL` for the frontend if the hubreceiver runs on another host.
 `HUB_URL` is also accepted by the frontend as a shortcut for `HUB_HTTP_URL`.
+The browser app uses the configured hub HTTP base for session, detail, usage, and history requests in split mode.
 
 ### Display name pools
 

--- a/claudeville/server.js
+++ b/claudeville/server.js
@@ -158,6 +158,41 @@ function handleGetUsage(req, res) {
   }
 }
 
+/**
+ * GET /api/history?lines=100
+ * 최근 메시지 이력 반환
+ */
+function handleGetHistory(req, res) {
+  try {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const limit = Number(url.searchParams.get('lines') || 100);
+    const safeLimit = Number.isFinite(limit) ? Math.min(Math.max(limit, 1), 500) : 100;
+    const sessions = getAllSessions(ACTIVE_THRESHOLD_MS);
+    const entries = [];
+
+    for (const session of sessions) {
+      const messages = session.detail?.messages || [];
+      for (const message of messages) {
+        if (!message || !message.text) continue;
+        entries.push({
+          provider: session.provider,
+          sessionId: session.sessionId,
+          project: session.project || null,
+          role: message.role || 'assistant',
+          text: message.text,
+          ts: message.ts || 0,
+        });
+      }
+    }
+
+    entries.sort((a, b) => a.ts - b.ts);
+    sendJson(res, 200, { entries: entries.slice(-safeLimit) });
+  } catch (err) {
+    console.error('히스토리 조회 실패:', err.message);
+    sendError(res, 500, '히스토리 정보를 불러올 수 없습니다.');
+  }
+}
+
 // ─── 정적 파일 서빙 ─────────────────────────────────────
 
 function handleStaticFile(req, res) {
@@ -486,6 +521,8 @@ const server = http.createServer((req, res) => {
         return handleGetProviders(req, res);
       case '/api/usage':
         return handleGetUsage(req, res);
+      case '/api/history':
+        return handleGetHistory(req, res);
     }
   }
 

--- a/claudeville/src/config/costs.js
+++ b/claudeville/src/config/costs.js
@@ -1,0 +1,12 @@
+export const CLAUDE_RATE_TABLE = {
+    'claude-opus-4-6': { input: 15, output: 75 },
+    'claude-sonnet-4-5': { input: 3, output: 15 },
+    'claude-haiku-4-5': { input: 0.8, output: 4 },
+};
+
+export function estimateClaudeCost(model, tokens = { input: 0, output: 0 }) {
+    const rate = CLAUDE_RATE_TABLE[model] || CLAUDE_RATE_TABLE['claude-sonnet-4-5'];
+    const input = Number(tokens?.input || 0);
+    const output = Number(tokens?.output || 0);
+    return ((input * rate.input) + (output * rate.output)) / 1000000;
+}

--- a/claudeville/src/config/runtime.js
+++ b/claudeville/src/config/runtime.js
@@ -8,6 +8,26 @@ export function getHubHttpUrl() {
     return config.hubHttpUrl || window.location.origin;
 }
 
+export function getHubApiUrl(pathname, searchParams) {
+    const url = new URL(pathname, getHubHttpUrl());
+
+    if (searchParams instanceof URLSearchParams) {
+        searchParams.forEach((value, key) => {
+            url.searchParams.set(key, value);
+        });
+    } else if (typeof searchParams === 'string' && searchParams.length > 0) {
+        url.search = searchParams.startsWith('?') ? searchParams : `?${searchParams}`;
+    } else if (searchParams && typeof searchParams === 'object') {
+        for (const [key, value] of Object.entries(searchParams)) {
+            if (value !== undefined && value !== null && value !== '') {
+                url.searchParams.set(key, String(value));
+            }
+        }
+    }
+
+    return url.toString();
+}
+
 export function getHubWsUrl() {
     return config.hubWsUrl || fallbackWsUrl();
 }

--- a/claudeville/src/domain/entities/Agent.js
+++ b/claudeville/src/domain/entities/Agent.js
@@ -2,6 +2,7 @@ import { AgentStatus } from '../value-objects/AgentStatus.js';
 import { Position } from '../value-objects/Position.js';
 import { Appearance } from '../value-objects/Appearance.js';
 import { generateAgentDisplayName, resolveAgentDisplayName } from '../../config/agentNames.js';
+import { estimateClaudeCost } from '../../config/costs.js';
 
 export class Agent {
     constructor({ id, name, nameSeed = null, nameKind = 'session', nameMode = 'autodetected', nameHint = null, model, status, role, tokens, messages, teamName, projectPath, lastTool, lastToolInput, lastMessage, provider }) {
@@ -38,13 +39,7 @@ export class Agent {
     }
 
     get cost() {
-        const rates = {
-            'claude-opus-4-6': { input: 15, output: 75 },
-            'claude-sonnet-4-5': { input: 3, output: 15 },
-            'claude-haiku-4-5': { input: 0.8, output: 4 },
-        };
-        const rate = rates[this.model] || rates['claude-sonnet-4-5'];
-        return (this.tokens.input * rate.input + this.tokens.output * rate.output) / 1000000;
+        return estimateClaudeCost(this.model, this.tokens);
     }
 
     get lastMessage() {

--- a/claudeville/src/infrastructure/ClaudeDataSource.js
+++ b/claudeville/src/infrastructure/ClaudeDataSource.js
@@ -1,11 +1,9 @@
-import { getHubHttpUrl } from '../config/runtime.js';
-
-const BASE_URL = getHubHttpUrl();
+import { getHubApiUrl } from '../config/runtime.js';
 
 export class ClaudeDataSource {
     async getSessions() {
         try {
-            const res = await fetch(`${BASE_URL}/api/sessions`);
+            const res = await fetch(getHubApiUrl('/api/sessions'));
             if (!res.ok) throw new Error(`HTTP ${res.status}`);
             const data = await res.json();
             return data.sessions || [];
@@ -17,7 +15,7 @@ export class ClaudeDataSource {
 
     async getTeams() {
         try {
-            const res = await fetch(`${BASE_URL}/api/teams`);
+            const res = await fetch(getHubApiUrl('/api/teams'));
             if (!res.ok) throw new Error(`HTTP ${res.status}`);
             const data = await res.json();
             return data.teams || [];
@@ -29,7 +27,7 @@ export class ClaudeDataSource {
 
     async getTasks() {
         try {
-            const res = await fetch(`${BASE_URL}/api/tasks`);
+            const res = await fetch(getHubApiUrl('/api/tasks'));
             if (!res.ok) throw new Error(`HTTP ${res.status}`);
             const data = await res.json();
             return data.taskGroups || [];
@@ -41,7 +39,7 @@ export class ClaudeDataSource {
 
     async getUsage() {
         try {
-            const res = await fetch(`${BASE_URL}/api/usage`);
+            const res = await fetch(getHubApiUrl('/api/usage'));
             if (!res.ok) throw new Error(`HTTP ${res.status}`);
             return await res.json();
         } catch (err) {
@@ -52,7 +50,7 @@ export class ClaudeDataSource {
 
     async getHistory(lines = 100) {
         try {
-            const res = await fetch(`${BASE_URL}/api/history?lines=${lines}`);
+            const res = await fetch(getHubApiUrl('/api/history', { lines }));
             if (!res.ok) throw new Error(`HTTP ${res.status}`);
             const data = await res.json();
             return data.entries || [];

--- a/claudeville/src/presentation/dashboard-mode/DashboardRenderer.js
+++ b/claudeville/src/presentation/dashboard-mode/DashboardRenderer.js
@@ -1,6 +1,7 @@
 import { eventBus } from '../../domain/events/DomainEvent.js';
 import { AvatarCanvas } from './AvatarCanvas.js';
 import { i18n } from '../../config/i18n.js';
+import { getHubApiUrl } from '../../config/runtime.js';
 
 const TOOL_ICONS = {
     Read: '📖', Edit: '✏️', Write: '📝', Grep: '🔍', Glob: '📁',
@@ -359,7 +360,7 @@ export class DashboardRenderer {
                 project: agent.projectPath || '',
                 provider: agent.provider || 'claude',
             });
-            const resp = await fetch(`/api/session-detail?${params}`);
+            const resp = await fetch(getHubApiUrl('/api/session-detail', params));
             if (!resp.ok) return;
             const data = await resp.json();
             if (data.toolHistory) {

--- a/claudeville/src/presentation/shared/ActivityPanel.js
+++ b/claudeville/src/presentation/shared/ActivityPanel.js
@@ -1,4 +1,6 @@
 import { eventBus } from '../../domain/events/DomainEvent.js';
+import { estimateClaudeCost } from '../../config/costs.js';
+import { getHubApiUrl } from '../../config/runtime.js';
 
 const TOOL_ICONS = {
     Read: '\u{1F4D6}', Edit: '\u270F\uFE0F', Write: '\u{1F4DD}',
@@ -121,7 +123,7 @@ export class ActivityPanel {
                 project: agent.projectPath || '',
                 provider: agent.provider || 'claude',
             });
-            const resp = await fetch(`/api/session-detail?${params}`);
+            const resp = await fetch(getHubApiUrl('/api/session-detail', params));
             if (!resp.ok) return;
             const data = await resp.json();
             if (this.currentAgent && this.currentAgent.id === agent.id) {
@@ -209,8 +211,11 @@ export class ActivityPanel {
         document.getElementById('panelTurnCount').textContent =
             usage.turnCount.toLocaleString();
 
-        // Estimated cost (Opus 4.6 기본 요금)
-        const cost = this._estimateCost(usage);
+        // Estimated cost uses the same source of truth as the world/top bar.
+        const cost = estimateClaudeCost(usage.model || 'claude-sonnet-4-5', {
+            input: usage.totalInput,
+            output: usage.totalOutput,
+        });
         document.getElementById('panelEstCost').textContent = `$${cost.toFixed(4)}`;
     }
 
@@ -218,16 +223,6 @@ export class ActivityPanel {
         if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
         if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
         return String(n);
-    }
-
-    _estimateCost(usage) {
-        // Opus 4.6 pricing: input $15/M, output $75/M, cache_read $1.5/M, cache_create $18.75/M
-        return (
-            (usage.totalInput * 15 / 1000000) +
-            (usage.totalOutput * 75 / 1000000) +
-            (usage.cacheRead * 1.5 / 1000000) +
-            (usage.cacheCreate * 18.75 / 1000000)
-        );
     }
 
     // ─── 유틸 ───────────────────────────────────────

--- a/docs/architecture/000-overall-spec.md
+++ b/docs/architecture/000-overall-spec.md
@@ -1,0 +1,175 @@
+# ClaudeVille Architecture Spec
+
+## Scope
+
+This spec describes the architecture of ClaudeVille after the changes merged on top of `upstream/main`.
+
+It covers:
+
+- the split-stack deployment model
+- the legacy single-process app
+- provider adapters and normalized session data
+- the browser UI structure
+- runtime configuration and environment variables
+- identity, naming, grouping, and cost presentation
+
+## System goals
+
+ClaudeVille is designed to:
+
+- visualize active AI coding sessions in near real time
+- support multiple provider CLIs with a shared UI and data model
+- run as either a local all-in-one app or a distributed collector / hub / frontend stack
+- keep the UI readable with stable names, project grouping, and provider badges
+- stay dependency-free and use platform-native Node.js / browser APIs only
+
+## Runtime modes
+
+### Legacy mode
+
+The legacy app runs from `claudeville/server.js` and serves:
+
+- the HTML shell
+- static CSS / JS assets
+- `/runtime-config.js`
+- the local session APIs
+- a WebSocket endpoint for live updates
+
+In this mode, the app reads local provider files directly through the adapter layer.
+
+### Split-stack mode
+
+The distributed stack is made of three parts:
+
+- `collector` watches local provider files and publishes snapshots
+- `hubreceiver` accepts snapshots, merges state, and exposes HTTP / WebSocket APIs
+- `frontend` serves the static browser UI and injects runtime config
+
+This mode is intended for cases where the browser UI runs remotely from the machine that owns the provider logs.
+
+## Source layout
+
+### `claudeville/src/domain`
+
+Pure domain entities and value objects:
+
+- `Agent`
+- `Building`
+- `Task`
+- `World`
+- `AgentStatus`, `Position`, `Appearance`
+
+### `claudeville/src/application`
+
+Application services orchestrate state and live updates:
+
+- `AgentManager`
+- `ModeManager`
+- `SessionWatcher`
+- `NotificationService`
+
+### `claudeville/src/infrastructure`
+
+Infrastructure adapters provide transport and data access:
+
+- `ClaudeDataSource`
+- `WebSocketClient`
+
+### `claudeville/src/presentation`
+
+UI rendering is split by mode:
+
+- `character-mode/` for the isometric world renderer and camera system
+- `dashboard-mode/` for project-grouped cards and per-session details
+- `shared/` for top bar, sidebar, modal, toast, and activity panel
+
+### `claudeville/adapters`
+
+Provider adapters normalize provider-specific session formats into a shared session contract.
+
+Current providers include:
+
+- Claude Code
+- Codex CLI
+- Gemini CLI
+- OpenClaw
+- GitHub Copilot CLI
+
+## Data flow
+
+### Legacy app data flow
+
+1. The app loads runtime configuration.
+2. `ClaudeDataSource` fetches session lists, teams, tasks, and usage.
+3. `SessionWatcher` keeps the world updated via WebSocket or polling fallback.
+4. `AgentManager` normalizes sessions into `World` entities.
+5. Presentation components render the world, dashboard, top bar, sidebar, and activity panel.
+
+### Split-stack data flow
+
+1. `collector` scans provider files and builds a snapshot.
+2. `hubreceiver` stores the latest snapshot per collector and merges the current state.
+3. The browser app reads state from the hubreceiver through the configured runtime URLs.
+4. Live updates flow over WebSocket from the hubreceiver.
+
+## UI structure
+
+The browser layout is intentionally fixed in broad structure, but implemented with flexbox rather than positioned panels:
+
+- top bar
+- left sidebar
+- center content area
+- optional right activity panel
+
+The content area switches between:
+
+- world mode: canvas-based isometric rendering
+- dashboard mode: card-based project grouping
+
+## Naming and identity
+
+ClaudeVille avoids raw provider IDs wherever possible.
+
+The current naming pipeline supports:
+
+- autodetected names when a human-friendly name already exists
+- pooled names for short stable labels
+- provider-specific overrides
+- separate pools for agent/team names and session names
+
+This keeps the sidebar, dashboard, and activity panel readable even when session IDs are long or unstable.
+
+## API surface
+
+The architecture exposes the following main data endpoints:
+
+- `/api/sessions`
+- `/api/session-detail`
+- `/api/teams`
+- `/api/tasks`
+- `/api/providers`
+- `/api/usage`
+- `/api/history` in the split hubreceiver
+
+The browser UI should always use the configured runtime base URL for remote deployments.
+
+## Branch delta since `upstream/main`
+
+The branch introduces the following major architectural changes:
+
+- OpenClaw provider support
+- GitHub Copilot provider support
+- split collector / hubreceiver / frontend runtime
+- shared runtime config generation for browser and Node entrypoints
+- short stable display names and naming pools
+- project grouping and provider-aware dashboard rendering
+- expanded activity panel token / tool / message inspection
+- richer docs and issue tracking for OpenClaw naming behavior
+
+## Constraints
+
+- no external npm dependencies
+- ES modules in `src/`
+- CommonJS in server / adapter entrypoints
+- port `4000` remains the legacy app default
+- CSS layout should remain flexbox-based for app chrome, with fixed positioning reserved for modal / toast only

--- a/docs/architecture/000-overall-spec.md
+++ b/docs/architecture/000-overall-spec.md
@@ -149,9 +149,9 @@ The architecture exposes the following main data endpoints:
 - `/api/tasks`
 - `/api/providers`
 - `/api/usage`
-- `/api/history` in the split hubreceiver
+- `/api/history` in the legacy app and split hubreceiver
 
-The browser UI should always use the configured runtime base URL for remote deployments.
+The browser UI should always use the configured runtime base URL for remote deployments, including session-detail, usage, and history fetches.
 
 ## Branch delta since `upstream/main`
 
@@ -163,7 +163,9 @@ The branch introduces the following major architectural changes:
 - shared runtime config generation for browser and Node entrypoints
 - short stable display names and naming pools
 - project grouping and provider-aware dashboard rendering
+- shared cost helper used by the world, top bar, and activity panel
 - expanded activity panel token / tool / message inspection
+- legacy `/api/history` restored for local mode parity
 - richer docs and issue tracking for OpenClaw naming behavior
 
 ## Constraints

--- a/docs/architecture/001-split-stack-runtime.md
+++ b/docs/architecture/001-split-stack-runtime.md
@@ -1,0 +1,30 @@
+# ADR 001: Split-stack runtime and shared runtime config
+
+## Status
+
+Accepted
+
+## Context
+
+ClaudeVille originally shipped as a single local Node process that read provider files directly and served the browser UI.
+
+That works well for a local machine, but it does not solve the remote-browser case where the machine that owns the logs is different from the machine that opens the dashboard.
+
+## Decision
+
+Introduce a split-stack topology:
+
+- `collector` runs close to the source machine and watches provider logs
+- `hubreceiver` accepts snapshots and exposes the merged API / WebSocket surface
+- `frontend` serves the static browser UI
+
+Use `runtime-config.shared.js` to generate a consistent browser configuration payload for both legacy and split-stack environments.
+
+Support `HUB_URL` as a convenience alias for `HUB_HTTP_URL` so existing setups can migrate without friction.
+
+## Consequences
+
+- ClaudeVille can be used locally or remotely with the same UI code.
+- Runtime configuration is centralized and consistent across entrypoints.
+- The system gains more moving parts, so documentation and validation matter more.
+- Browser-side code must treat the configured runtime base URL as authoritative in split mode.

--- a/docs/architecture/002-provider-adapters.md
+++ b/docs/architecture/002-provider-adapters.md
@@ -1,0 +1,29 @@
+# ADR 002: Normalized multi-provider adapter contract
+
+## Status
+
+Accepted
+
+## Context
+
+Provider CLIs store session history in different file formats and directory layouts.
+
+Without a normalized adapter contract, every new provider would duplicate parsing logic and UI code would need provider-specific branches everywhere.
+
+## Decision
+
+Keep a dedicated adapter per provider under `claudeville/adapters/` and require each adapter to provide the same core behavior:
+
+- detect whether the provider is installed / available
+- enumerate active sessions
+- resolve a single session’s detail view
+- expose watch paths for live updates
+
+The registry in `claudeville/adapters/index.js` remains the aggregator that merges adapter output into the shared session model.
+
+## Consequences
+
+- New providers can be added without changing the rendering pipeline.
+- Session data is normalized before it reaches application services.
+- Adapter implementations remain file-format-specific, which keeps provider logic isolated.
+- Some parsing logic is duplicated today and should be kept under review for future refactors.

--- a/docs/architecture/003-identity-and-grouping.md
+++ b/docs/architecture/003-identity-and-grouping.md
@@ -1,0 +1,31 @@
+# ADR 003: Stable identity, display-name pools, and project grouping
+
+## Status
+
+Accepted
+
+## Context
+
+Raw provider session IDs are often long, unstable, or unreadable in the UI.
+
+At the same time, the dashboard needs to group sessions into meaningful project sections and keep team-related information visible.
+
+## Decision
+
+Use the naming pipeline in `claudeville/src/config/agentNames.js` to resolve readable names with these rules:
+
+- prefer autodetected names when they already look human-friendly
+- fall back to pooled short names when needed
+- allow provider-specific mode overrides
+- keep separate pools for agent/team names and session names
+
+Preserve project metadata and use it for dashboard grouping, sidebar organization, and activity-panel context.
+
+OpenClaw and Copilot adapters should expose stable identifiers that can survive repeated refreshes, while the UI remains focused on readable labels.
+
+## Consequences
+
+- the sidebar and dashboard are easier to scan
+- provider-specific naming differences are hidden from the user
+- the app can still preserve the underlying stable session identity for detail lookups
+- group labels become more predictable across refreshes and WebSocket updates

--- a/docs/architecture/004-api-and-cost-model.md
+++ b/docs/architecture/004-api-and-cost-model.md
@@ -15,6 +15,8 @@ The UI presents token counts, activity, and estimated costs in multiple places:
 
 To remain trustworthy, these values need a clear ownership model and compatible data shape across all renderers.
 
+The branch also restored `/api/history` on the legacy server so the local all-in-one mode matches the split hubreceiver API shape.
+
 ## Decision
 
 Define a shared session contract that includes:
@@ -26,7 +28,9 @@ Define a shared session contract that includes:
 - `lastTool`
 - `lastToolInput`
 
-Treat the split hubreceiver as the canonical source for `/api/history` and merged session detail data.
+Centralize Claude cost estimation in `claudeville/src/config/costs.js` and have the domain world plus UI surfaces reuse that helper instead of maintaining separate formulas.
+
+Treat the split hubreceiver as the canonical source for merged session detail data, while also keeping `/api/history` available in the legacy server for parity.
 
 Keep the legacy server responsible for the local all-in-one APIs, while the split-stack browser should use the runtime-configured hub URL for remote data access.
 

--- a/docs/architecture/004-api-and-cost-model.md
+++ b/docs/architecture/004-api-and-cost-model.md
@@ -1,0 +1,38 @@
+# ADR 004: API ownership and cost / token presentation
+
+## Status
+
+Accepted
+
+## Context
+
+The UI presents token counts, activity, and estimated costs in multiple places:
+
+- the top bar
+- the activity panel
+- dashboard cards
+- the macOS widget
+
+To remain trustworthy, these values need a clear ownership model and compatible data shape across all renderers.
+
+## Decision
+
+Define a shared session contract that includes:
+
+- `tokens`
+- `tokenUsage`
+- `estimatedCost`
+- `lastMessage`
+- `lastTool`
+- `lastToolInput`
+
+Treat the split hubreceiver as the canonical source for `/api/history` and merged session detail data.
+
+Keep the legacy server responsible for the local all-in-one APIs, while the split-stack browser should use the runtime-configured hub URL for remote data access.
+
+## Consequences
+
+- the UI can render the same session data in multiple places without provider-specific branching
+- cost calculations remain comparable across dashboard, widget, and activity views
+- the API contract becomes explicit enough to document and test
+- call sites must use the correct base URL for their deployment mode

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,7 +10,7 @@ This folder documents the current architecture of ClaudeVille and the main decis
 | `001-split-stack-runtime.md` | ADR for the collector / hubreceiver / frontend topology and runtime configuration model. |
 | `002-provider-adapters.md` | ADR for the normalized multi-provider adapter contract. |
 | `003-identity-and-grouping.md` | ADR for stable display names, provider-aware naming, and project grouping. |
-| `004-api-and-cost-model.md` | ADR for API surface ownership and cost/token presentation semantics. |
+| `004-api-and-cost-model.md` | ADR for API surface ownership, history parity, and cost/token presentation semantics. |
 
 ## Reading order
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,19 @@
+# ClaudeVille Architecture
+
+This folder documents the current architecture of ClaudeVille and the main decisions introduced since `upstream/main`.
+
+## Documents
+
+| File | Purpose |
+| --- | --- |
+| `000-overall-spec.md` | High-level architecture spec for the branch state after the split-stack and provider-expansion work. |
+| `001-split-stack-runtime.md` | ADR for the collector / hubreceiver / frontend topology and runtime configuration model. |
+| `002-provider-adapters.md` | ADR for the normalized multi-provider adapter contract. |
+| `003-identity-and-grouping.md` | ADR for stable display names, provider-aware naming, and project grouping. |
+| `004-api-and-cost-model.md` | ADR for API surface ownership and cost/token presentation semantics. |
+
+## Reading order
+
+1. Start with the overall spec.
+2. Read the ADRs in numeric order.
+3. Use the ADRs as the source of truth when changing architecture-sensitive code.

--- a/docs/issues/openclaw-plugin-agentnames.md
+++ b/docs/issues/openclaw-plugin-agentnames.md
@@ -1,8 +1,0 @@
-OpenClaw doesnt automatically recognize the correct agentids
-
-
-Openclaw has ~/.openclaw/agents/[agentid]/sessions
-so agent "clawson" would have sessions in ~/.openclaw/agents/clawson/sessions
-agent reseacher would have sessions in ~/.openclaw/agents/researcher/sessions
-
-the plugin should automatically name the agent in the dashboard based on the agentid in the path, but it currently just names all agents "agent" which is not helpful when you have multiple agents.


### PR DESCRIPTION
Introduce comprehensive architecture documentation for the split-stack and provider expansion. Implement a history retrieval API and improve cost estimation logic for better accuracy and consistency across the application. Restore legacy API history endpoint to ensure local mode parity.