### PR TITLE
Refine sanitization and websocket observability

### DIFF
--- a/claudeville/adapters/claude.test.js
+++ b/claudeville/adapters/claude.test.js
@@ -42,3 +42,50 @@ test('uses stable encoded project fallback for orphan sessions', () => {
     os.homedir = originalHomedir;
   }
 });
+
+test('keeps hyphenated project paths stable when a mapped project exists', () => {
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-ville-claude-map-'));
+  const originalHomedir = os.homedir;
+  os.homedir = () => tmpHome;
+
+  try {
+    const projectPath = '/Users/openclaw/Github/my-repo-with-hyphen';
+    const encodedProjectDir = projectPath.replace(/\//g, '-');
+    const projectsDir = path.join(tmpHome, '.claude', 'projects', encodedProjectDir, 'session-1', 'subagents');
+    fs.mkdirSync(projectsDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(tmpHome, '.claude', 'history.jsonl'),
+      [
+        JSON.stringify({
+          timestamp: Date.now(),
+          project: projectPath,
+        }),
+      ].join('\n')
+    );
+
+    const subagentFile = path.join(projectsDir, 'agent-abc.jsonl');
+    fs.writeFileSync(subagentFile, [
+      JSON.stringify({
+        timestamp: Date.now(),
+        message: {
+          role: 'assistant',
+          model: 'claude-sonnet-4-5',
+          content: [{ type: 'text', text: 'subagent message' }],
+        },
+      }),
+    ].join('\n'));
+
+    delete require.cache[require.resolve('./claude')];
+    const { ClaudeAdapter } = require('./claude');
+    const adapter = new ClaudeAdapter();
+
+    const sessions = adapter.getActiveSessions(60 * 1000);
+    const subagent = sessions.find((s) => s.sessionId === 'subagent-abc');
+    assert.ok(subagent, 'expected subagent session to be discovered');
+    assert.equal(subagent.project, projectPath);
+    assert.equal(subagent.agentType, 'sub-agent');
+  } finally {
+    os.homedir = originalHomedir;
+  }
+});

--- a/claudeville/adapters/index.test.js
+++ b/claudeville/adapters/index.test.js
@@ -144,8 +144,10 @@ test('getAllSessions aggregates, sanitizes, and forwards filePath for detail loo
     assert.equal(sessions[1].sessionId, 'c-1');
 
     const claudeSession = sessions.find((s) => s.sessionId === 'c-1');
-    assert.equal(claudeSession.lastMessage, null);
+    assert.equal(claudeSession.lastMessage, 'file_count 279 ageSec=0');
     assert.equal(claudeSession.lastToolInput, '/tmp/path');
+    assert.equal(claudeSession.rawLastMessage, 'file_count 279 ageSec=0');
+    assert.equal(claudeSession.rawLastToolInput, '  /tmp/path  ');
     assert.equal(claudeSession.detail.messages.length, 1);
     assert.equal(claudeSession.detail.messages[0].text, 'meaningful output');
     assert.deepEqual(claudeSession.tokens, { input: 1200, output: 300 });

--- a/claudeville/adapters/sanitize.js
+++ b/claudeville/adapters/sanitize.js
@@ -11,6 +11,10 @@ function normalizeWhitespace(value) {
     .trim();
 }
 
+function summarizeText(value, maxLen = 200) {
+  return normalizeWhitespace(value).substring(0, maxLen);
+}
+
 function looksLikeNoise(text) {
   if (!text) return true;
 
@@ -28,9 +32,9 @@ function looksLikeNoise(text) {
 }
 
 function cleanText(value, maxLen = 200) {
-  const text = normalizeWhitespace(value);
+  const text = summarizeText(value, maxLen);
   if (!text || looksLikeNoise(text)) return '';
-  return text.substring(0, maxLen);
+  return text;
 }
 
 function sanitizeToolHistory(toolHistory = []) {
@@ -39,7 +43,7 @@ function sanitizeToolHistory(toolHistory = []) {
   return toolHistory
     .map((item) => ({
       ...item,
-      tool: cleanText(item?.tool || '', 80) || (item?.tool || 'unknown'),
+      tool: summarizeText(item?.tool || '', 80) || (item?.tool || 'unknown'),
       detail: cleanText(item?.detail || '', 140),
     }))
     .filter((item) => item.tool || item.detail);
@@ -67,8 +71,10 @@ function sanitizeSessionDetail(detail = {}) {
 function sanitizeSessionSummary(session = {}) {
   return {
     ...session,
-    lastMessage: cleanText(session?.lastMessage || '', 120) || null,
-    lastToolInput: cleanText(session?.lastToolInput || '', 80) || null,
+    rawLastMessage: session?.lastMessage ?? null,
+    rawLastToolInput: session?.lastToolInput ?? null,
+    lastMessage: summarizeText(session?.lastMessage || '', 120) || null,
+    lastToolInput: summarizeText(session?.lastToolInput || '', 80) || null,
   };
 }
 
@@ -76,4 +82,5 @@ module.exports = {
   cleanText,
   sanitizeSessionDetail,
   sanitizeSessionSummary,
+  summarizeText,
 };

--- a/claudeville/adapters/sanitize.test.js
+++ b/claudeville/adapters/sanitize.test.js
@@ -30,6 +30,20 @@ test('sanitizeSessionSummary cleans last message and tool input', () => {
 
   assert.equal(session.lastMessage, 'useful update from model');
   assert.equal(session.lastToolInput, '/Users/me/project/file.js');
+  assert.equal(session.rawLastMessage, '  useful update from model  ');
+  assert.equal(session.rawLastToolInput, '   /Users/me/project/file.js   ');
+});
+
+test('sanitizeSessionSummary preserves noisy raw values', () => {
+  const session = sanitizeSessionSummary({
+    lastMessage: 'file_count 279 ageSec=0 size=...',
+    lastToolInput: 'vscodeCount= 1',
+  });
+
+  assert.equal(session.lastMessage, 'file_count 279 ageSec=0 size=...');
+  assert.equal(session.lastToolInput, 'vscodeCount= 1');
+  assert.equal(session.rawLastMessage, 'file_count 279 ageSec=0 size=...');
+  assert.equal(session.rawLastToolInput, 'vscodeCount= 1');
 });
 
 test('sanitizeSessionDetail drops noisy messages and keeps valid ones', () => {

--- a/claudeville/adapters/vscode.test.js
+++ b/claudeville/adapters/vscode.test.js
@@ -82,6 +82,64 @@ test('collects VS Code + Insiders Copilot Chat sessions from debug logs', async 
   }
 });
 
+test('prefers debug logs over newer transcript and resource candidates for the same session', async () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-ville-vscode-priority-'));
+  const oldCodeDir = process.env.VSCODE_USER_DATA_DIR;
+  const oldInsidersDir = process.env.VSCODE_INSIDERS_USER_DATA_DIR;
+
+  process.env.VSCODE_USER_DATA_DIR = path.join(tmpRoot, 'Code', 'User');
+  process.env.VSCODE_INSIDERS_USER_DATA_DIR = path.join(tmpRoot, 'Code - Insiders', 'User');
+
+  try {
+    const workspace = path.join(process.env.VSCODE_USER_DATA_DIR, 'workspaceStorage', 'ws-priority');
+    fs.mkdirSync(workspace, { recursive: true });
+    fs.writeFileSync(path.join(workspace, 'workspace.json'), JSON.stringify({ folder: 'file:///tmp/project-priority' }));
+
+    const debugFile = path.join(workspace, 'GitHub.copilot-chat', 'debug-logs', 'shared-session', 'main.jsonl');
+    writeJsonLines(debugFile, [
+      { ts: Date.now() - 4000, type: 'llm_request', attrs: { model: 'gpt-5.3', inputTokens: 1, outputTokens: 2 } },
+      { ts: Date.now() - 3900, type: 'agent_response', attrs: { response: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'debug source wins' }] }]) } },
+    ]);
+
+    const transcriptFile = path.join(workspace, 'GitHub.copilot-chat', 'transcripts', 'shared-session.jsonl');
+    writeJsonLines(transcriptFile, [
+      { type: 'assistant.message', data: { content: 'transcript source should lose' }, timestamp: new Date(Date.now() - 2000).toISOString() },
+    ]);
+
+    const resourceFile = path.join(
+      workspace,
+      'GitHub.copilot-chat',
+      'chat-session-resources',
+      'shared-session',
+      'call_1__tool',
+      'content.txt'
+    );
+    fs.mkdirSync(path.dirname(resourceFile), { recursive: true });
+    fs.writeFileSync(resourceFile, 'resource source should lose');
+
+    const nowSec = Date.now() / 1000;
+    fs.utimesSync(debugFile, nowSec - 4, nowSec - 4);
+    fs.utimesSync(transcriptFile, nowSec - 2, nowSec - 2);
+    fs.utimesSync(resourceFile, nowSec - 1, nowSec - 1);
+
+    delete require.cache[require.resolve('./vscode')];
+    const { VSCodeAdapter } = require('./vscode');
+    const adapter = new VSCodeAdapter();
+
+    const sessions = await adapter.getActiveSessions(60 * 1000);
+    assert.equal(sessions.length, 1);
+    assert.equal(sessions[0].sessionId, 'vscode:vscode:ws-priority:shared-session');
+    assert.ok(sessions[0].filePath.endsWith(path.join('GitHub.copilot-chat', 'debug-logs', 'shared-session', 'main.jsonl')));
+    assert.equal(sessions[0].lastMessage, 'debug source wins');
+  } finally {
+    if (oldCodeDir === undefined) delete process.env.VSCODE_USER_DATA_DIR;
+    else process.env.VSCODE_USER_DATA_DIR = oldCodeDir;
+
+    if (oldInsidersDir === undefined) delete process.env.VSCODE_INSIDERS_USER_DATA_DIR;
+    else process.env.VSCODE_INSIDERS_USER_DATA_DIR = oldInsidersDir;
+  }
+});
+
 test('collects active session from chat-session-resources content files', async () => {
   const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-ville-vscode-resources-'));
   const oldCodeDir = process.env.VSCODE_USER_DATA_DIR;

--- a/claudeville/server.js
+++ b/claudeville/server.js
@@ -290,10 +290,7 @@ function handleWebSocketUpgrade(req, socket) {
     try {
       handleWebSocketFrame(socket, buffer);
     } catch (err) {
-      // 프레임 처리 에러 무시 (필요 시 trace 로그)
-      if (process.env.CLAUDEVILLE_TRACE_WS === '1') {
-        console.warn('[WebSocket] frame handling error:', err instanceof Error ? err.message : String(err));
-      }
+      reportWebSocketFrameIssue(socket, 'frame handling error', err);
     }
   });
 
@@ -317,6 +314,11 @@ function handleWebSocketFrame(socket, buffer) {
   let payloadLength = secondByte & 0x7f;
   let offset = 2;
 
+  if (!isMasked) {
+    reportWebSocketFrameIssue(socket, 'client frame was not masked');
+    return;
+  }
+
   if (payloadLength === 126) {
     if (buffer.length < 4) return;
     payloadLength = buffer.readUInt16BE(2);
@@ -327,20 +329,15 @@ function handleWebSocketFrame(socket, buffer) {
     offset = 10;
   }
 
-  let maskKey = null;
-  if (isMasked) {
-    if (buffer.length < offset + 4) return;
-    maskKey = buffer.slice(offset, offset + 4);
-    offset += 4;
-  }
+  if (buffer.length < offset + 4) return;
+  const maskKey = buffer.slice(offset, offset + 4);
+  offset += 4;
 
   if (buffer.length < offset + payloadLength) return;
 
   const payload = buffer.slice(offset, offset + payloadLength);
-  if (isMasked && maskKey) {
-    for (let i = 0; i < payload.length; i++) {
-      payload[i] ^= maskKey[i % 4];
-    }
+  for (let i = 0; i < payload.length; i++) {
+    payload[i] ^= maskKey[i % 4];
   }
 
   switch (opcode) {
@@ -356,6 +353,9 @@ function handleWebSocketFrame(socket, buffer) {
       break;
     case 0xa:
       break;
+    default:
+      reportWebSocketFrameIssue(socket, `unsupported opcode 0x${opcode.toString(16)}`);
+      break;
   }
 }
 
@@ -365,7 +365,9 @@ function handleTextMessage(socket, message) {
     if (data.type === 'ping') {
       wsSend(socket, { type: 'pong', timestamp: Date.now() });
     }
-  } catch { /* 무시 */ }
+  } catch (err) {
+    reportWebSocketFrameIssue(socket, 'invalid JSON text frame', err);
+  }
 }
 
 function createWebSocketFrame(data, opcode = 0x1) {
@@ -418,6 +420,32 @@ function wsBroadcast(data) {
     } catch {
       wsClients.delete(socket);
     }
+  }
+}
+
+const WS_FRAME_ISSUE_WINDOW_MS = 5000;
+const WS_FRAME_ISSUE_CLOSE_THRESHOLD = 3;
+
+function reportWebSocketFrameIssue(socket, reason, err) {
+  const now = Date.now();
+  const state = socket._claudevilleWsFrameIssue || { count: 0, lastLoggedAt: 0 };
+  state.count += 1;
+
+  if (state.count === 1 || now - state.lastLoggedAt >= WS_FRAME_ISSUE_WINDOW_MS) {
+    const suffix = err ? `: ${err instanceof Error ? err.message : String(err)}` : '';
+    console.warn(`[WebSocket] ${reason}${suffix}`);
+    state.lastLoggedAt = now;
+  }
+
+  socket._claudevilleWsFrameIssue = state;
+
+  if (state.count >= WS_FRAME_ISSUE_CLOSE_THRESHOLD && !socket.destroyed) {
+    try {
+      socket.end(createWebSocketFrame('', 0x8));
+    } catch {
+      socket.destroy();
+    }
+    wsClients.delete(socket);
   }
 }
 


### PR DESCRIPTION
## Summary
- Preserve raw summary fields alongside sanitized display values
- Narrow sanitization to detailed provider-generated text
- Make malformed WebSocket frames observable by default and close after repeated violations
- Add regression coverage for Claude project mapping and VS Code source-priority dedupe

## Verification
- node --test claudeville/**/*.test.js
- Server startup, REST endpoints, CORS, and WebSocket ping verified locally
