### PR TITLE
🧹 Remove console.log statements from WebSocketClient

### DIFF
--- a/claudeville/src/infrastructure/WebSocketClient.ts
+++ b/claudeville/src/infrastructure/WebSocketClient.ts
@@ -30,7 +30,6 @@ export class WebSocketClient {
             this.ws.onopen = () => {
                 this.connected = true;
                 this.reconnectAttempts = 0;
-                console.log('[WS] Connected');
                 eventBus.emit('ws:connected');
                 this._clearReconnect();
             };
@@ -46,7 +45,6 @@ export class WebSocketClient {
 
             this.ws.onclose = () => {
                 this.connected = false;
-                console.log('[WS] Disconnected');
                 eventBus.emit('ws:disconnected');
                 this._scheduleReconnect();
             };
@@ -102,9 +100,6 @@ export class WebSocketClient {
             30000
         );
         this.reconnectTimer = setTimeout(() => {
-            if (this.reconnectAttempts > 3) {
-                console.log(`[WS] Reconnecting... (retry in ${Math.round(delay / 1000)}s)`);
-            }
             this.connect();
         }, delay);
     }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- Removed redundant `console.log` statements in `claudeville/src/infrastructure/WebSocketClient.ts` that were being used for connection status and reconnection attempts.

💡 **Why:** How this improves maintainability
- Prevents console clutter in production environments.
- Reduces risk of information leaks (e.g., connection details, retry timing).
- Cleans up the code by removing logs that are better handled by proper monitoring or aren't needed for normal operation.

✅ **Verification:** How you confirmed the change is safe
- Verified removal of logs by reading the modified source file.
- Performed syntax validation using `node -c`.
- Changes are purely observational (logging) and do not affect the logic or flow of the WebSocket connection and reconnection process.

✨ **Result:** The improvement achieved
- A cleaner console output for users and developers.
- A more professional and production-ready WebSocket infrastructure client.

---
*PR created automatically by Jules for task [17277661606436714006](https://jules.google.com/task/17277661606436714006) started by @deadronos*