### PR TITLE
🔒 Remove hardcoded fallback for HUB_AUTH_TOKEN

### DIFF
--- a/hubreceiver/server.ts
+++ b/hubreceiver/server.ts
@@ -4,7 +4,10 @@ const http = require('http');
 const { applySnapshot, getCurrentState, getSessionDetail, getHistory, defaultUsage } = require('./state');
 
 const PORT = Number(process.env.HUB_PORT || 3030);
-const AUTH_TOKEN = process.env.HUB_AUTH_TOKEN || 'dev-secret';
+const AUTH_TOKEN = process.env.HUB_AUTH_TOKEN;
+if (!AUTH_TOKEN) {
+  throw new Error('HUB_AUTH_TOKEN environment variable is required');
+}
 const MAX_SNAPSHOT_BYTES = Number(process.env.MAX_SNAPSHOT_BYTES || 10 * 1024 * 1024); // 10 MB default
 
 const wsClients = new Set();


### PR DESCRIPTION
🎯 **What:** Removed the hardcoded fallback value `'dev-secret'` for the `HUB_AUTH_TOKEN` environment variable in `hubreceiver/server.ts`.
⚠️ **Risk:** If left unfixed, the server would default to a well-known secret if the environment variable was not properly configured, potentially allowing unauthorized access to the `/api/collector/snapshot` endpoint in production-like environments.
🛡️ **Solution:** The server now checks if `process.env.HUB_AUTH_TOKEN` is defined during startup. If it is missing, the server throws an error and fails to start, ensuring that it only runs in a secure, properly configured state.

---
*PR created automatically by Jules for task [2743523330534288890](https://jules.google.com/task/2743523330534288890) started by @deadronos*