### PR TITLE
🧹 Extract Building Styles Configuration

### DIFF
--- a/claudeville/src/config/buildingStyles.ts
+++ b/claudeville/src/config/buildingStyles.ts
@@ -1,0 +1,61 @@
+export interface BuildingStyle {
+    wallColor: string;
+    roofColor: string;
+    accentColor: string;
+    wallHeight: number;
+    roundRoof?: boolean;
+    hasAntenna?: boolean;
+    hasFlag?: boolean;
+    windowGlow?: boolean;
+    hasChimney?: boolean;
+    hasAnvil?: boolean;
+    hasMineEntrance?: boolean;
+    hasPickaxe?: boolean;
+    hasGems?: boolean;
+    hasPostits?: boolean;
+    hasBubble?: boolean;
+}
+
+export const BUILDING_STYLES: Record<string, BuildingStyle> = {
+    command: {
+        wallColor: '#5a3e2b',
+        roofColor: '#8b0000',
+        accentColor: '#ffd700',
+        wallHeight: 50,
+        hasAntenna: true,
+        hasFlag: true,
+        windowGlow: true,
+    },
+    forge: {
+        wallColor: '#4a3520',
+        roofColor: '#555555',
+        accentColor: '#ff6b00',
+        wallHeight: 40,
+        hasChimney: true,
+        hasAnvil: true,
+    },
+    mine: {
+        wallColor: '#3e3530',
+        roofColor: '#5a4a3a',
+        accentColor: '#ffd700',
+        wallHeight: 35,
+        hasMineEntrance: true,
+        hasPickaxe: true,
+        hasGems: true,
+    },
+    taskboard: {
+        wallColor: '#4a4035',
+        roofColor: '#6b5b4a',
+        accentColor: '#4a9eff',
+        wallHeight: 30,
+        hasPostits: true,
+    },
+    chathall: {
+        wallColor: '#3a4a5a',
+        roofColor: '#5a7a9a',
+        accentColor: '#51cf66',
+        wallHeight: 38,
+        roundRoof: true,
+        hasBubble: true,
+    },
+};

--- a/claudeville/src/presentation/character-mode/BuildingRenderer.ts
+++ b/claudeville/src/presentation/character-mode/BuildingRenderer.ts
@@ -1,49 +1,6 @@
 import { TILE_WIDTH, TILE_HEIGHT } from '../../config/constants.js';
 import { THEME } from '../../config/theme.js';
-
-const BUILDING_STYLES = {
-    command: {
-        wallColor: '#5a3e2b',
-        roofColor: '#8b0000',
-        accentColor: '#ffd700',
-        wallHeight: 50,
-        hasAntenna: true,
-        hasFlag: true,
-        windowGlow: true,
-    },
-    forge: {
-        wallColor: '#4a3520',
-        roofColor: '#555555',
-        accentColor: '#ff6b00',
-        wallHeight: 40,
-        hasChimney: true,
-        hasAnvil: true,
-    },
-    mine: {
-        wallColor: '#3e3530',
-        roofColor: '#5a4a3a',
-        accentColor: '#ffd700',
-        wallHeight: 35,
-        hasMineEntrance: true,
-        hasPickaxe: true,
-        hasGems: true,
-    },
-    taskboard: {
-        wallColor: '#4a4035',
-        roofColor: '#6b5b4a',
-        accentColor: '#4a9eff',
-        wallHeight: 30,
-        hasPostits: true,
-    },
-    chathall: {
-        wallColor: '#3a4a5a',
-        roofColor: '#5a7a9a',
-        accentColor: '#51cf66',
-        wallHeight: 38,
-        hasRoundRoof: true,
-        hasBubble: true,
-    },
-};
+import { BUILDING_STYLES } from '../../config/buildingStyles.js';
 
 export class BuildingRenderer {
     particleSystem: any;
@@ -237,7 +194,7 @@ export class BuildingRenderer {
         if (alpha > 0.05) {
             ctx.save();
             ctx.globalAlpha = alpha;
-            if (style.hasRoundRoof) {
+            if (style.roundRoof) {
                 this._drawRoundRoof(ctx, halfW, halfH, style);
             } else {
                 this._drawTriangleRoof(ctx, halfW, halfH, style);

--- a/claudeville/src/presentation/react/world/styles.ts
+++ b/claudeville/src/presentation/react/world/styles.ts
@@ -1,37 +1,5 @@
-import type { BuildingStyle } from './types.js';
+import { BUILDING_STYLES } from '../../../config/buildingStyles.js';
 
 export const MINIMAP_SIZE = 150;
 
-export const BUILDING_STYLES: Record<string, BuildingStyle> = {
-  command: {
-    wallColor: '#5a3e2b',
-    roofColor: '#8b0000',
-    accentColor: '#ffd700',
-    wallHeight: 50,
-  },
-  forge: {
-    wallColor: '#4a3520',
-    roofColor: '#555555',
-    accentColor: '#ff6b00',
-    wallHeight: 40,
-  },
-  mine: {
-    wallColor: '#3e3530',
-    roofColor: '#5a4a3a',
-    accentColor: '#ffd700',
-    wallHeight: 35,
-  },
-  taskboard: {
-    wallColor: '#4a4035',
-    roofColor: '#6b5b4a',
-    accentColor: '#4a9eff',
-    wallHeight: 30,
-  },
-  chathall: {
-    wallColor: '#3a4a5a',
-    roofColor: '#5a7a9a',
-    accentColor: '#51cf66',
-    wallHeight: 38,
-    roundRoof: true,
-  },
-};
+export { BUILDING_STYLES };

--- a/claudeville/src/presentation/react/world/types.ts
+++ b/claudeville/src/presentation/react/world/types.ts
@@ -1,6 +1,9 @@
 import type { MutableRefObject } from 'react';
 
 import type { AgentSprite } from '../../character-mode/AgentSprite.js';
+import type { BuildingStyle } from '../../../config/buildingStyles.js';
+
+export type { BuildingStyle };
 
 export type BubbleConfig = {
   textScale: number;
@@ -32,14 +35,6 @@ export type TerrainTileModel = {
   y: number;
   color: string;
   water: boolean;
-};
-
-export type BuildingStyle = {
-  wallColor: string;
-  roofColor: string;
-  accentColor: string;
-  wallHeight: number;
-  roundRoof?: boolean;
 };
 
 export type InteractionModel = {


### PR DESCRIPTION
The `BUILDING_STYLES` configuration has been moved from `BuildingRenderer.ts` to `claudeville/src/config/buildingStyles.ts`. This change also consolidates a duplicate configuration found in the React styles, unifying property names and centralizing the source of truth for building appearances.

---
*PR created automatically by Jules for task [6234555426588076324](https://jules.google.com/task/6234555426588076324) started by @deadronos*