### PR TITLE
Add debug logging to adapter catch blocks

### DIFF
--- a/claudeville/adapters/claude.ts
+++ b/claudeville/adapters/claude.ts
@@ -5,6 +5,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const { debugAdapterError } = require('./jsonl-utils');
 
 // Type for directory entries from readdirSync with withFileTypes: true
 type Dirent = { name: string; isDirectory(): boolean; isFile(): boolean; isSymlink(): boolean };
@@ -30,7 +31,8 @@ function readLastLines(filePath: string, lineCount: number) {
     const content = fs.readFileSync(filePath, 'utf-8');
     const lines = content.trim().split('\n');
     return lines.slice(-lineCount);
-  } catch {
+  } catch (err) {
+    debugAdapterError('claude', 'readLastLines', err, filePath);
     return [];
   }
 }
@@ -39,7 +41,9 @@ function parseJsonLines(lines: string[]) {
   const results = [];
   for (const line of lines) {
     if (!line.trim()) continue;
-    try { results.push(JSON.parse(line)); } catch { /* ignore */ }
+    try { results.push(JSON.parse(line)); } catch (err) {
+      debugAdapterError('claude', 'parseJsonLines', err, line.substring(0, 120));
+    }
   }
   return results;
 }
@@ -85,7 +89,9 @@ function getSessionDetail(sessionId: string, projectPath: string | null) {
       }
       if (detail.model && detail.lastTool && detail.lastMessage) break;
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('claude', 'getSessionDetail', err, sessionFile);
+  }
 
   return detail;
 }
@@ -122,7 +128,9 @@ function getSubAgentDetail(filePath: string) {
       }
       if (detail.model && detail.lastTool && detail.lastMessage) break;
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('claude', 'getSubAgentDetail', err, filePath);
+  }
   return detail;
 }
 
@@ -153,7 +161,9 @@ function getToolHistory(sessionFilePath: string, maxItems = 15) {
         tools.push({ tool: block.name || 'unknown', detail, ts: entry.timestamp || 0 });
       }
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('claude', 'getToolHistory', err, sessionFilePath);
+  }
   return tools.slice(-maxItems);
 }
 
@@ -176,7 +186,9 @@ function getRecentMessages(sessionFilePath: string, maxItems = 5) {
         messages.push({ role: msg.role, text: text.substring(0, 200), ts: entry.timestamp || 0 });
       }
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('claude', 'getRecentMessages', err, sessionFilePath);
+  }
   return messages.slice(-maxItems);
 }
 
@@ -213,7 +225,9 @@ function getTokenUsage(sessionFilePath: string) {
         (lastUsage.cache_read_input_tokens || 0) +
         (lastUsage.cache_creation_input_tokens || 0);
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('claude', 'getTokenUsage', err, sessionFilePath);
+  }
   return usage;
 }
 
@@ -231,7 +245,9 @@ function resolveSessionFilePath(sessionId: string, project: string | null) {
         const agentFile = path.join(projectsDir, dir.name, 'subagents', `agent-${agentId}.jsonl`);
         if (fs.existsSync(agentFile)) return agentFile;
       }
-    } catch { /* ignore */ }
+    } catch (err) {
+      debugAdapterError('claude', 'resolveSessionFilePath', err, projectsDir);
+    }
     return null;
   }
 
@@ -245,7 +261,9 @@ function getSessionFileActivity(sessionId: string, project: string | null) {
   const sessionFile = path.join(CLAUDE_DIR, 'projects', encoded, `${sessionId}.jsonl`);
   try {
     if (fs.existsSync(sessionFile)) return fs.statSync(sessionFile).mtimeMs;
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('claude', 'getSessionFileActivity', err, sessionFile);
+  }
   return 0;
 }
 
@@ -343,7 +361,10 @@ class ClaudeAdapter {
         try {
           sessionDirs = fs.readdirSync(projPath, { withFileTypes: true })
             .filter((d: Dirent) => d.isDirectory());
-        } catch { continue; }
+        } catch (err) {
+          debugAdapterError('claude', 'getActiveSubAgents readdir project', err, projPath);
+          continue;
+        }
 
         for (const sessionDir of sessionDirs) {
           const subagentsDir = path.join(projPath, sessionDir.name, 'subagents');
@@ -353,12 +374,18 @@ class ClaudeAdapter {
           try {
             agentFiles = fs.readdirSync(subagentsDir)
               .filter((f: string) => f.startsWith('agent-') && f.endsWith('.jsonl'));
-          } catch { continue; }
+          } catch (err) {
+            debugAdapterError('claude', 'getActiveSubAgents readdir subagents', err, subagentsDir);
+            continue;
+          }
 
           for (const agentFile of agentFiles) {
             const filePath = path.join(subagentsDir, agentFile);
             let stat;
-            try { stat = fs.statSync(filePath); } catch { continue; }
+            try { stat = fs.statSync(filePath); } catch (err) {
+              debugAdapterError('claude', 'getActiveSubAgents stat', err, filePath);
+              continue;
+            }
 
             if (now - stat.mtimeMs > activeThresholdMs) continue;
 
@@ -384,7 +411,9 @@ class ClaudeAdapter {
           }
         }
       }
-    } catch { /* ignore */ }
+    } catch (err) {
+      debugAdapterError('claude', 'getActiveSubAgents', err, projectsDir);
+    }
 
     return results;
   }
@@ -406,7 +435,10 @@ class ClaudeAdapter {
         try {
           files = fs.readdirSync(projPath)
             .filter((f: string) => f.endsWith('.jsonl') && !f.startsWith('.'));
-        } catch { continue; }
+        } catch (err) {
+          debugAdapterError('claude', 'getOrphanSessions readdir project', err, projPath);
+          continue;
+        }
 
         for (const file of files) {
           const sessionId = file.replace('.jsonl', '');
@@ -415,7 +447,10 @@ class ClaudeAdapter {
 
           const filePath = path.join(projPath, file);
           let stat;
-          try { stat = fs.statSync(filePath); } catch { continue; }
+          try { stat = fs.statSync(filePath); } catch (err) {
+            debugAdapterError('claude', 'getOrphanSessions stat', err, filePath);
+            continue;
+          }
 
           if (now - stat.mtimeMs > activeThresholdMs) continue;
 
@@ -437,7 +472,9 @@ class ClaudeAdapter {
           });
         }
       }
-    } catch { /* ignore */ }
+    } catch (err) {
+      debugAdapterError('claude', 'getOrphanSessions', err, projectsDir);
+    }
 
     return results;
   }
@@ -475,7 +512,9 @@ class ClaudeAdapter {
             recursive: true,
           });
         }
-      } catch { /* ignore */ }
+      } catch (err) {
+        debugAdapterError('claude', 'getWatchPaths', err, projectsDir);
+      }
     }
 
     // Teams directory (detect team creation/changes)
@@ -506,13 +545,15 @@ class ClaudeAdapter {
             return { teamName: dir.name, ...config };
           } catch (err) {
             if (err instanceof Error && 'code' in err && err.code === 'ENOENT') return null;
+            debugAdapterError('claude', 'getTeams read/parse config', err, configPath);
             return { teamName: dir.name, error: 'parse failed' };
           }
         });
 
       const results = await Promise.all(teamPromises);
       return results.filter(Boolean);
-    } catch {
+    } catch (err) {
+      debugAdapterError('claude', 'getTeams readdir', err, TEAMS_DIR);
       return [];
     }
   }
@@ -532,7 +573,8 @@ class ClaudeAdapter {
               try {
                 const content = await fs.promises.readFile(path.join(groupDir, file), 'utf-8');
                 return JSON.parse(content);
-              } catch {
+              } catch (err) {
+                debugAdapterError('claude', 'getTasks read/parse task', err, path.join(groupDir, file));
                 return null;
               }
             });
@@ -543,14 +585,16 @@ class ClaudeAdapter {
               tasks: tasks.sort((a, b) => Number(a.id || 0) - Number(b.id || 0)),
               count: tasks.length,
             };
-          } catch {
+          } catch (err) {
+            debugAdapterError('claude', 'getTasks readdir group', err, groupDir);
             return null;
           }
         });
 
       const taskGroups = (await Promise.all(groupPromises)).filter(Boolean);
       return taskGroups;
-    } catch {
+    } catch (err) {
+      debugAdapterError('claude', 'getTasks readdir', err, TASKS_DIR);
       return [];
     }
   }

--- a/claudeville/adapters/codex.ts
+++ b/claudeville/adapters/codex.ts
@@ -11,7 +11,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { readLines, parseJsonLines } = require('./jsonl-utils');
+const { debugAdapterError, readLines, parseJsonLines } = require('./jsonl-utils');
 
 const CODEX_DIR = path.join(os.homedir(), '.codex');
 const SESSIONS_DIR = path.join(CODEX_DIR, 'sessions');
@@ -43,8 +43,8 @@ async function parseRollout(filePath: string) {
   };
 
   // session_meta is on the first line of the file → read first
-  const firstLines = await readLines(filePath, { from: 'start', count: 5 });
-  const firstEntries = parseJsonLines(firstLines);
+  const firstLines = await readLines(filePath, { from: 'start', count: 5, scope: 'codex' });
+  const firstEntries = parseJsonLines(firstLines, 'codex');
   for (const entry of firstEntries) {
     if (entry.type === 'session_meta' && entry.payload) {
       detail.model = entry.payload.model || null;
@@ -54,8 +54,8 @@ async function parseRollout(filePath: string) {
   }
 
   // Recent tools/messages are read from end of file
-  const lastLines = await readLines(filePath, { from: 'end', count: 50 });
-  const entries = parseJsonLines(lastLines);
+  const lastLines = await readLines(filePath, { from: 'end', count: 50, scope: 'codex' });
+  const entries = parseJsonLines(lastLines, 'codex');
 
   for (const entry of entries) {
     const payload = entry.payload;
@@ -113,8 +113,8 @@ async function parseRollout(filePath: string) {
 async function getToolHistory(filePath: string, maxItems = 15) {
   const tools = [];
   try {
-    const lines = await readLines(filePath, { from: 'end', count: 100 });
-    const entries = parseJsonLines(lines);
+    const lines = await readLines(filePath, { from: 'end', count: 100, scope: 'codex' });
+    const entries = parseJsonLines(lines, 'codex');
 
     for (const entry of entries) {
       if (entry.type !== 'response_item' || !entry.payload) continue;
@@ -136,7 +136,9 @@ async function getToolHistory(filePath: string, maxItems = 15) {
         });
       }
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('codex', 'getToolHistory', err, filePath);
+  }
   return tools.slice(-maxItems);
 }
 
@@ -146,8 +148,8 @@ async function getToolHistory(filePath: string, maxItems = 15) {
 async function getRecentMessages(filePath: string, maxItems = 5) {
   const messages = [];
   try {
-    const lines = await readLines(filePath, { from: 'end', count: 60 });
-    const entries = parseJsonLines(lines);
+    const lines = await readLines(filePath, { from: 'end', count: 60, scope: 'codex' });
+    const entries = parseJsonLines(lines, 'codex');
 
     for (const entry of entries) {
       if (entry.type !== 'response_item' || !entry.payload) continue;
@@ -178,7 +180,9 @@ async function getRecentMessages(filePath: string, maxItems = 5) {
         });
       }
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('codex', 'getRecentMessages', err, filePath);
+  }
   return messages.slice(-maxItems);
 }
 
@@ -232,24 +236,28 @@ async function scanRecentRollouts(activeThresholdMs: number) {
                     const stat = await fs.promises.stat(filePath);
                     if (now - stat.mtimeMs > activeThresholdMs) return null;
                     return { filePath, mtime: stat.mtimeMs, fileName: file };
-                  } catch {
+                  } catch (err) {
+                    debugAdapterError('codex', 'scanRecentRollouts stat', err, filePath);
                     return null;
                   }
                 }));
                 return fileResults.filter(Boolean);
-              } catch {
+              } catch (err) {
+                debugAdapterError('codex', 'scanRecentRollouts readdir day', err, dayDir);
                 return [];
               }
             }));
 
             return dayResults.flat();
-          } catch {
+          } catch (err) {
+            debugAdapterError('codex', 'scanRecentRollouts readdir month', err, monthDir);
             return [];
           }
         }));
 
         return monthResults.flat();
-      } catch {
+      } catch (err) {
+        debugAdapterError('codex', 'scanRecentRollouts readdir year', err, yearDir);
         return [];
       }
     }));
@@ -257,7 +265,9 @@ async function scanRecentRollouts(activeThresholdMs: number) {
     for (const group of yearResults) {
       results.push(...group);
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('codex', 'scanRecentRollouts', err, SESSIONS_DIR);
+  }
 
   return results;
 }

--- a/claudeville/adapters/copilot.ts
+++ b/claudeville/adapters/copilot.ts
@@ -13,7 +13,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { readLines, parseJsonLines } = require('./jsonl-utils');
+const { debugAdapterError, readLines, parseJsonLines } = require('./jsonl-utils');
 
 const COPILOT_DIR = path.join(os.homedir(), '.copilot');
 const SESSION_STATE_DIR = path.join(COPILOT_DIR, 'session-state');
@@ -35,8 +35,8 @@ async function parseSession(filePath: string) {
   };
 
   // Extract metadata from session.start
-  const firstLines = await readLines(filePath, { from: 'start', count: 5 });
-  const firstEntries = parseJsonLines(firstLines);
+  const firstLines = await readLines(filePath, { from: 'start', count: 5, scope: 'copilot' });
+  const firstEntries = parseJsonLines(firstLines, 'copilot');
   for (const entry of firstEntries) {
     if (entry.type === 'session.start' && entry.data) {
       if (!detail.model && entry.data.selectedModel) {
@@ -50,8 +50,8 @@ async function parseSession(filePath: string) {
   }
 
   // Extract tools/messages from the rest
-  const lastLines = await readLines(filePath, { from: 'end', count: 80 });
-  const entries = parseJsonLines(lastLines);
+  const lastLines = await readLines(filePath, { from: 'end', count: 80, scope: 'copilot' });
+  const entries = parseJsonLines(lastLines, 'copilot');
 
   for (let i = entries.length - 1; i >= 0; i--) {
     const entry = entries[i];
@@ -120,8 +120,8 @@ function extractText(content: unknown) {
 async function getToolHistory(filePath: string, maxItems = 15) {
   const tools = [];
   try {
-    const lines = await readLines(filePath, { from: 'end', count: 100 });
-    const entries = parseJsonLines(lines);
+    const lines = await readLines(filePath, { from: 'end', count: 100, scope: 'copilot' });
+    const entries = parseJsonLines(lines, 'copilot');
 
     for (const entry of entries) {
       let toolName = null;
@@ -154,7 +154,9 @@ async function getToolHistory(filePath: string, maxItems = 15) {
         tools.push({ tool: toolName, detail: toolInput || '', ts });
       }
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('copilot', 'getToolHistory', err, filePath);
+  }
   return tools.slice(-maxItems);
 }
 
@@ -163,8 +165,8 @@ async function getToolHistory(filePath: string, maxItems = 15) {
 async function getRecentMessages(filePath: string, maxItems = 5) {
   const messages = [];
   try {
-    const lines = await readLines(filePath, { from: 'end', count: 60 });
-    const entries = parseJsonLines(lines);
+    const lines = await readLines(filePath, { from: 'end', count: 60, scope: 'copilot' });
+    const entries = parseJsonLines(lines, 'copilot');
 
     for (const entry of entries) {
       if (entry.type !== 'user.message' && entry.type !== 'assistant.message') continue;
@@ -179,7 +181,9 @@ async function getRecentMessages(filePath: string, maxItems = 5) {
         ts: entry.timestamp ? new Date(entry.timestamp).getTime() : 0,
       });
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('copilot', 'getRecentMessages', err, filePath);
+  }
   return messages.slice(-maxItems);
 }
 
@@ -207,13 +211,16 @@ async function scanAllSessions(activeThresholdMs: number) {
           mtime: stat.mtimeMs,
           sessionId: sessionDir.name,
         };
-      } catch {
+      } catch (err) {
+        debugAdapterError('copilot', 'scanAllSessions stat', err, eventsFile);
         return null;
       }
     }));
 
     results.push(...dirResults.filter(Boolean));
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('copilot', 'scanAllSessions', err, SESSION_STATE_DIR);
+  }
 
   return results;
 }

--- a/claudeville/adapters/index.ts
+++ b/claudeville/adapters/index.ts
@@ -4,6 +4,7 @@
  */
 const { estimateCost } = require('../../shared/cost.ts');
 const { normalizeTokens } = require('../../shared/session-utils.js');
+const { debugAdapterError } = require('./jsonl-utils');
 const { sanitizeSessionDetail, sanitizeSessionSummary } = require('./sanitize.ts');
 const { ClaudeAdapter } = require('./claude.ts');
 const { CodexAdapter } = require('./codex.ts');
@@ -79,8 +80,8 @@ function getAllWatchPaths() {
     if (!adapter.isAvailable()) continue;
     try {
       paths.push(...adapter.getWatchPaths());
-    } catch {
-      // ignore
+    } catch (err) {
+      debugAdapterError('adapters', 'getAllWatchPaths', err, adapter.name);
     }
   }
   return paths;

--- a/claudeville/adapters/jsonl-utils.js
+++ b/claudeville/adapters/jsonl-utils.js
@@ -5,20 +5,29 @@
  */
 const fs = require('fs');
 
+function debugAdapterError(scope, operation, err, context = '') {
+  if (!process.env.DEBUG) return;
+
+  const message = err instanceof Error ? err.message : String(err);
+  const suffix = context ? ` ${context}` : '';
+  console.debug(`[${scope}] ${operation}${suffix}: ${message}`);
+}
+
 /**
  * Read the last N (or first N) lines of a file as strings.
  * @param {string} filePath
  * @param {{ from: 'start'|'end', count: number }} options
  * @returns {Promise<string[]>}
  */
-async function readLines(filePath, { from = 'end', count = 50 } = {}) {
+async function readLines(filePath, { from = 'end', count = 50, scope = 'jsonl-utils' } = {}) {
   try {
     if (!fs.existsSync(filePath)) return [];
     const content = await fs.promises.readFile(filePath, 'utf-8');
     const lines = content.trim().split('\n');
     if (from === 'start') return lines.slice(0, count);
     return lines.slice(-count);
-  } catch {
+  } catch (err) {
+    debugAdapterError(scope, `readLines(${from})`, err, filePath);
     return [];
   }
 }
@@ -28,13 +37,15 @@ async function readLines(filePath, { from = 'end', count = 50 } = {}) {
  * @param {string[]} lines
  * @returns {object[]}
  */
-function parseJsonLines(lines) {
+function parseJsonLines(lines, scope = 'jsonl-utils') {
   const results = [];
   for (const line of lines) {
     if (!line.trim()) continue;
-    try { results.push(JSON.parse(line)); } catch { /* ignore */ }
+    try { results.push(JSON.parse(line)); } catch (err) {
+      debugAdapterError(scope, 'parseJsonLines', err, line.substring(0, 120));
+    }
   }
   return results;
 }
 
-module.exports = { readLines, parseJsonLines };
+module.exports = { debugAdapterError, readLines, parseJsonLines };

--- a/claudeville/adapters/openclaw.ts
+++ b/claudeville/adapters/openclaw.ts
@@ -10,7 +10,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { readLines, parseJsonLines } = require('./jsonl-utils');
+const { debugAdapterError, readLines, parseJsonLines } = require('./jsonl-utils');
 
 const OPENCLAW_DIR = path.join(os.homedir(), '.openclaw');
 const AGENTS_DIR = path.join(OPENCLAW_DIR, 'agents');
@@ -32,8 +32,8 @@ async function parseSession(filePath: string) {
     lastMessage: null,
   };
 
-  const lines = await readLines(filePath, { from: 'end', count: 80 });
-  const entries = parseJsonLines(lines);
+  const lines = await readLines(filePath, { from: 'end', count: 80, scope: 'openclaw' });
+  const entries = parseJsonLines(lines, 'openclaw');
 
   // Iterate in reverse from the end
   for (let i = entries.length - 1; i >= 0; i--) {
@@ -107,8 +107,8 @@ function extractText(content: unknown) {
 async function getToolHistory(filePath: string, maxItems = 15) {
   const tools = [];
   try {
-    const lines = await readLines(filePath, { from: 'end', count: 100 });
-    const entries = parseJsonLines(lines);
+    const lines = await readLines(filePath, { from: 'end', count: 100, scope: 'openclaw' });
+    const entries = parseJsonLines(lines, 'openclaw');
 
     for (const entry of entries) {
       if (entry.type !== 'message' || !entry.message) continue;
@@ -130,7 +130,9 @@ async function getToolHistory(filePath: string, maxItems = 15) {
         });
       }
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('openclaw', 'getToolHistory', err, filePath);
+  }
   return tools.slice(-maxItems);
 }
 
@@ -139,8 +141,8 @@ async function getToolHistory(filePath: string, maxItems = 15) {
 async function getRecentMessages(filePath: string, maxItems = 5) {
   const messages = [];
   try {
-    const lines = await readLines(filePath, { from: 'end', count: 60 });
-    const entries = parseJsonLines(lines);
+    const lines = await readLines(filePath, { from: 'end', count: 60, scope: 'openclaw' });
+    const entries = parseJsonLines(lines, 'openclaw');
 
     for (const entry of entries) {
       if (entry.type !== 'message' || !entry.message) continue;
@@ -156,7 +158,9 @@ async function getRecentMessages(filePath: string, maxItems = 5) {
         ts: entry.timestamp ? new Date(entry.timestamp).getTime() : 0,
       });
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('openclaw', 'getRecentMessages', err, filePath);
+  }
   return messages.slice(-maxItems);
 }
 
@@ -228,13 +232,15 @@ async function scanAllSessionFiles(activeThresholdMs: number): Promise<OpenClawS
                   fileName: file,
                   agentId: agentDir.name,
                 };
-              } catch {
+              } catch (err) {
+                debugAdapterError('openclaw', 'scanAllSessionFiles stat', err, filePath);
                 return null;
               }
             })
           );
           return fileResults.filter((r: OpenClawScanResult | null): r is OpenClawScanResult => r !== null);
-        } catch {
+        } catch (err) {
+          debugAdapterError('openclaw', 'scanAllSessionFiles readdir sessions', err, sessionsDir);
           return [];
         }
       })
@@ -242,7 +248,9 @@ async function scanAllSessionFiles(activeThresholdMs: number): Promise<OpenClawS
     for (const group of agentResults) {
       results.push(...group);
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('openclaw', 'scanAllSessionFiles', err, AGENTS_DIR);
+  }
 
   return results;
 }
@@ -327,7 +335,9 @@ class OpenClawAdapter {
           paths.push({ type: 'directory', path: sessionsDir, filter: '.jsonl' });
         }
       }
-    } catch { /* ignore */ }
+    } catch (err) {
+      debugAdapterError('openclaw', 'getWatchPaths', err, AGENTS_DIR);
+    }
 
     return paths;
   }

--- a/claudeville/adapters/pi.ts
+++ b/claudeville/adapters/pi.ts
@@ -11,7 +11,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { readLines, parseJsonLines } = require('./jsonl-utils');
+const { debugAdapterError, readLines, parseJsonLines } = require('./jsonl-utils');
 
 const PI_DIR = path.join(os.homedir(), '.pi');
 const SESSIONS_DIR = path.join(PI_DIR, 'agent', 'sessions');
@@ -39,8 +39,8 @@ async function parseSession(filePath: string) {
     lastMessage: null,
   };
 
-  const lines = await readLines(filePath, { from: 'end', count: 80 });
-  const entries = parseJsonLines(lines);
+  const lines = await readLines(filePath, { from: 'end', count: 80, scope: 'pi' });
+  const entries = parseJsonLines(lines, 'pi');
 
   // Iterate in reverse from the end
   for (let i = entries.length - 1; i >= 0; i--) {
@@ -115,8 +115,8 @@ function extractText(content: unknown) {
 async function getToolHistory(filePath: string, maxItems = 15) {
   const tools = [];
   try {
-    const lines = await readLines(filePath, { from: 'end', count: 100 });
-    const entries = parseJsonLines(lines);
+    const lines = await readLines(filePath, { from: 'end', count: 100, scope: 'pi' });
+    const entries = parseJsonLines(lines, 'pi');
 
     for (const entry of entries) {
       if (entry.type !== 'message' || !entry.message) continue;
@@ -138,7 +138,9 @@ async function getToolHistory(filePath: string, maxItems = 15) {
         });
       }
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('pi', 'getToolHistory', err, filePath);
+  }
   return tools.slice(-maxItems);
 }
 
@@ -147,8 +149,8 @@ async function getToolHistory(filePath: string, maxItems = 15) {
 async function getRecentMessages(filePath: string, maxItems = 5) {
   const messages = [];
   try {
-    const lines = await readLines(filePath, { from: 'end', count: 60 });
-    const entries = parseJsonLines(lines);
+    const lines = await readLines(filePath, { from: 'end', count: 60, scope: 'pi' });
+    const entries = parseJsonLines(lines, 'pi');
 
     for (const entry of entries) {
       if (entry.type !== 'message' || !entry.message) continue;
@@ -164,7 +166,9 @@ async function getRecentMessages(filePath: string, maxItems = 5) {
         ts: entry.timestamp ? new Date(entry.timestamp).getTime() : 0,
       });
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('pi', 'getRecentMessages', err, filePath);
+  }
   return messages.slice(-maxItems);
 }
 
@@ -243,13 +247,15 @@ async function scanAllSessionFiles(activeThresholdMs: number): Promise<ScanResul
                   fileName: file,
                   projectDir: projectDir.name,
                 } as ScanResult;
-              } catch {
+              } catch (err) {
+                debugAdapterError('pi', 'scanAllSessionFiles stat', err, filePath);
                 return null;
               }
             })
           );
           return fileResults.filter((r: ScanResult | null): r is ScanResult => r !== null);
-        } catch {
+        } catch (err) {
+          debugAdapterError('pi', 'scanAllSessionFiles readdir project', err, projectPath);
           return [];
         }
       })
@@ -258,7 +264,9 @@ async function scanAllSessionFiles(activeThresholdMs: number): Promise<ScanResul
     for (const group of dirResults) {
       results.push(...group);
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('pi', 'scanAllSessionFiles', err, SESSIONS_DIR);
+  }
 
   return results;
 }
@@ -336,7 +344,9 @@ class PiAdapter {
 
     try {
       paths.push({ type: 'directory', path: SESSIONS_DIR, recursive: true, filter: '.jsonl' });
-    } catch { /* ignore */ }
+    } catch (err) {
+      debugAdapterError('pi', 'getWatchPaths', err, SESSIONS_DIR);
+    }
 
     return paths;
   }

--- a/claudeville/adapters/vscode.ts
+++ b/claudeville/adapters/vscode.ts
@@ -7,7 +7,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { readLines, parseJsonLines } = require('./jsonl-utils');
+const { debugAdapterError, readLines, parseJsonLines } = require('./jsonl-utils');
 
 const VSCODE_USER_DIR = process.env.VSCODE_USER_DATA_DIR
   || path.join(os.homedir(), 'Library', 'Application Support', 'Code', 'User');
@@ -79,13 +79,15 @@ async function scanResourceSessionContents(filePath: string): Promise<Array<{ ca
             text: String(text || '').trim(),
             ts: stat.mtimeMs,
           };
-        } catch {
+        } catch (err) {
+          debugAdapterError('vscode', 'scanResourceSessionContents file', err, contentPath);
           return null;
         }
       }));
 
     entries = contentRows.filter(Boolean).sort((a, b) => a.ts - b.ts);
-  } catch {
+  } catch (err) {
+    debugAdapterError('vscode', 'scanResourceSessionContents', err, sessionRoot);
     entries = [];
   }
 
@@ -109,7 +111,8 @@ function extractAssistantText(responseRaw: string) {
         }
       }
     }
-  } catch {
+  } catch (err) {
+    debugAdapterError('vscode', 'extractAssistantText', err, responseRaw.substring(0, 120));
     // JSON parse failed; use raw text as-is
     return responseRaw.substring(0, 200).trim();
   }
@@ -139,14 +142,14 @@ async function parseSession(filePath: string) {
       if (normalized) {
         detail.lastMessage = normalized.substring(0, 120);
       }
-    } catch {
-      // ignore
+    } catch (err) {
+      debugAdapterError('vscode', 'parseSession content.txt', err, filePath);
     }
     return detail;
   }
 
-  const lines = await readLines(filePath, { from: 'end', count: 300 });
-  const entries = parseJsonLines(lines);
+  const lines = await readLines(filePath, { from: 'end', count: 300, scope: 'vscode' });
+  const entries = parseJsonLines(lines, 'vscode');
 
   for (let i = entries.length - 1; i >= 0; i--) {
     const entry = entries[i];
@@ -216,8 +219,8 @@ async function getToolHistory(filePath: string, maxItems = 15) {
   }
 
   try {
-    const lines = await readLines(filePath, { from: 'end', count: 300 });
-    const entries = parseJsonLines(lines);
+    const lines = await readLines(filePath, { from: 'end', count: 300, scope: 'vscode' });
+    const entries = parseJsonLines(lines, 'vscode');
 
     for (const entry of entries) {
       if (entry.type !== 'tool_call') continue;
@@ -233,11 +236,13 @@ async function getToolHistory(filePath: string, maxItems = 15) {
         tools.push({
           tool: entry.data.toolName || 'tool.execution_start',
           detail: summarizeJson(entry.data.arguments, 120),
-        ts: typeof entry.timestamp === 'number' ? entry.timestamp : 0,
+          ts: typeof entry.timestamp === 'number' ? entry.timestamp : 0,
         });
       }
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('vscode', 'getToolHistory', err, filePath);
+  }
 
   return tools.slice(-maxItems);
 }
@@ -267,8 +272,8 @@ async function getRecentMessages(filePath: string, maxItems = 5) {
             ts: fs.existsSync(filePath) ? fs.statSync(filePath).mtimeMs : 0,
           });
         }
-      } catch {
-        // ignore
+      } catch (err) {
+        debugAdapterError('vscode', 'getRecentMessages content.txt', err, filePath);
       }
     }
 
@@ -276,8 +281,8 @@ async function getRecentMessages(filePath: string, maxItems = 5) {
   }
 
   try {
-    const lines = await readLines(filePath, { from: 'end', count: 300 });
-    const entries = parseJsonLines(lines);
+    const lines = await readLines(filePath, { from: 'end', count: 300, scope: 'vscode' });
+    const entries = parseJsonLines(lines, 'vscode');
 
     for (const entry of entries) {
       if (entry.type !== 'agent_response' || !entry.attrs) continue;
@@ -300,7 +305,9 @@ async function getRecentMessages(filePath: string, maxItems = 5) {
         ts: typeof entry.timestamp === 'number' ? entry.timestamp : 0,
       });
     }
-  } catch { /* ignore */ }
+  } catch (err) {
+    debugAdapterError('vscode', 'getRecentMessages', err, filePath);
+  }
 
   return messages.slice(-maxItems);
 }
@@ -317,8 +324,8 @@ async function readWorkspacePath(workspaceDir: string): Promise<string | null> {
     if (typeof uri === 'string' && uri.startsWith('file://')) {
       return decodeURIComponent(uri.replace('file://', ''));
     }
-  } catch {
-    // ignore
+  } catch (err) {
+    debugAdapterError('vscode', 'readWorkspacePath', err, workspaceFile);
   }
 
   return null;
@@ -350,7 +357,8 @@ async function scanAllSessions(activeThresholdMs: number) {
     let workspaceDirs = [];
     try {
       workspaceDirs = await fs.promises.readdir(root.workspaceStorageDir, { withFileTypes: true });
-    } catch {
+    } catch (err) {
+      debugAdapterError('vscode', 'scanAllSessions readdir workspaceStorage', err, root.workspaceStorageDir);
       continue;
     }
 
@@ -371,7 +379,8 @@ async function scanAllSessions(activeThresholdMs: number) {
           let debugLogDirs = [];
           try {
             debugLogDirs = await fs.promises.readdir(debugLogsDir, { withFileTypes: true });
-          } catch {
+          } catch (err) {
+            debugAdapterError('vscode', 'scanAllSessions readdir debug-logs', err, debugLogsDir);
             debugLogDirs = [];
           }
 
@@ -393,7 +402,8 @@ async function scanAllSessions(activeThresholdMs: number) {
                   project: projectPath || `vscode:${root.channel}:${workspaceId}`,
                   mtime: stat.mtimeMs,
                 };
-              } catch {
+              } catch (err) {
+                debugAdapterError('vscode', 'scanAllSessions stat debug log', err, mainLogFile);
                 return null;
               }
             }));
@@ -407,7 +417,8 @@ async function scanAllSessions(activeThresholdMs: number) {
           let transcriptFiles = [];
           try {
             transcriptFiles = await fs.promises.readdir(transcriptsDir);
-          } catch {
+          } catch (err) {
+            debugAdapterError('vscode', 'scanAllSessions readdir transcripts', err, transcriptsDir);
             transcriptFiles = [];
           }
 
@@ -428,7 +439,8 @@ async function scanAllSessions(activeThresholdMs: number) {
                   project: projectPath || `vscode:${root.channel}:${workspaceId}`,
                   mtime: stat.mtimeMs,
                 };
-              } catch {
+              } catch (err) {
+                debugAdapterError('vscode', 'scanAllSessions stat transcript', err, transcriptPath);
                 return null;
               }
             }));
@@ -442,7 +454,8 @@ async function scanAllSessions(activeThresholdMs: number) {
           let sessionDirs = [];
           try {
             sessionDirs = await fs.promises.readdir(resourcesDir, { withFileTypes: true });
-          } catch {
+          } catch (err) {
+            debugAdapterError('vscode', 'scanAllSessions readdir resources', err, resourcesDir);
             sessionDirs = [];
           }
 
@@ -453,7 +466,8 @@ async function scanAllSessions(activeThresholdMs: number) {
               let toolDirs = [];
               try {
                 toolDirs = await fs.promises.readdir(sessionRoot, { withFileTypes: true });
-              } catch {
+              } catch (err) {
+                debugAdapterError('vscode', 'scanAllSessions readdir resource session', err, sessionRoot);
                 return null;
               }
 
@@ -464,7 +478,8 @@ async function scanAllSessions(activeThresholdMs: number) {
                 try {
                   const stat = await fs.promises.stat(contentFile);
                   return { filePath: contentFile, mtime: stat.mtimeMs };
-                } catch {
+                } catch (err) {
+                  debugAdapterError('vscode', 'scanAllSessions stat content', err, contentFile);
                   return null;
                 }
               });


### PR DESCRIPTION
Add DEBUG-gated logging for adapter I/O and JSON parsing failures while preserving the existing ignore behavior.\n\nValidation:\n- npx vitest run claudeville/adapters/*.test.ts\n- npm run typecheck