### PR TITLE
Add adapter contract and unify backend ESM

### DIFF
--- a/claudeville/adapters/claude.test.ts
+++ b/claudeville/adapters/claude.test.ts
@@ -1179,7 +1179,7 @@ describe('claude adapter', () => {
     it('getSessionDetail returns expected structure', async () => {
       const adapter = new ClaudeAdapter();
       // Test with non-existent session to get empty result structure
-      const detail = adapter.getSessionDetail('nonexistent-session', '/nonexistent/project');
+      const detail = await adapter.getSessionDetail('nonexistent-session', '/nonexistent/project');
 
       expect(detail).toHaveProperty('toolHistory');
       expect(detail).toHaveProperty('messages');
@@ -1189,7 +1189,7 @@ describe('claude adapter', () => {
 
     it('getSessionDetail returns empty arrays for unknown session', async () => {
       const adapter = new ClaudeAdapter();
-      const detail = adapter.getSessionDetail('unknown-session-12345', '/unknown/project/path');
+      const detail = await adapter.getSessionDetail('unknown-session-12345', '/unknown/project/path');
 
       expect(detail.toolHistory).toEqual([]);
       expect(detail.messages).toEqual([]);

--- a/claudeville/adapters/claude.ts
+++ b/claudeville/adapters/claude.ts
@@ -2,13 +2,15 @@
  * Claude Code CLI adapter
  * Data source: ~/.claude/
  */
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-const { debugAdapterError } = require('./jsonl-utils');
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import type { AgentAdapter, WatchPath } from '../../shared/types.js';
+import { debugAdapterError } from './jsonl-utils.js';
 
 // Type for directory entries from readdirSync with withFileTypes: true
-type Dirent = { name: string; isDirectory(): boolean; isFile(): boolean; isSymlink(): boolean };
+type Dirent = { name: string; isDirectory(): boolean; isFile(): boolean };
 
 const CLAUDE_DIR = process.env.CLAUDE_DIR || path.join(os.homedir(), '.claude');
 const HISTORY_FILE = path.join(CLAUDE_DIR, 'history.jsonl');
@@ -269,7 +271,7 @@ function getSessionFileActivity(sessionId: string, project: string | null) {
 
 // ─── Adapter class ──────────────────────────────────────
 
-class ClaudeAdapter {
+export class ClaudeAdapter implements AgentAdapter {
   get name() { return 'Claude Code'; }
   get provider() { return 'claude'; }
   get homeDir() { return CLAUDE_DIR; }
@@ -278,7 +280,7 @@ class ClaudeAdapter {
     return fs.existsSync(CLAUDE_DIR);
   }
 
-  getActiveSessions(activeThresholdMs: number) {
+  async getActiveSessions(activeThresholdMs: number) {
     const lines = readLastLines(HISTORY_FILE, 1000);
     const entries = parseJsonLines(lines);
     const now = Date.now();
@@ -479,19 +481,19 @@ class ClaudeAdapter {
     return results;
   }
 
-  getSessionDetail(sessionId: string, project: string | null) {
-    const filePath = resolveSessionFilePath(sessionId, project);
-    if (!filePath) return { toolHistory: [], messages: [], tokenUsage: null };
+  async getSessionDetail(sessionId: string, project: string | null, filePath: string | null = null) {
+    const sessionFilePath = filePath || resolveSessionFilePath(sessionId, project);
+    if (!sessionFilePath) return { toolHistory: [], messages: [], tokenUsage: null };
     return {
-      toolHistory: getToolHistory(filePath),
-      messages: getRecentMessages(filePath),
-      tokenUsage: getTokenUsage(filePath),
+      toolHistory: getToolHistory(sessionFilePath),
+      messages: getRecentMessages(sessionFilePath),
+      tokenUsage: getTokenUsage(sessionFilePath),
       sessionId,
     };
   }
 
-  getWatchPaths() {
-    const paths = [];
+  getWatchPaths(): WatchPath[] {
+    const paths: WatchPath[] = [];
 
     // history.jsonl
     if (fs.existsSync(HISTORY_FILE)) {
@@ -599,5 +601,3 @@ class ClaudeAdapter {
     }
   }
 }
-
-module.exports = { ClaudeAdapter };

--- a/claudeville/adapters/codex.ts
+++ b/claudeville/adapters/codex.ts
@@ -8,16 +8,18 @@
  *   {"type":"response_item","payload":{"type":"message","role":"assistant","content":[...]}}
  *   {"type":"event_msg","payload":{"type":"turn_complete","usage":{...}}}
  */
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-const { debugAdapterError, readLines, parseJsonLines } = require('./jsonl-utils');
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import type { AgentAdapter, WatchPath } from '../../shared/types.js';
+import { debugAdapterError, readLines, parseJsonLines } from './jsonl-utils.js';
 
 const CODEX_DIR = path.join(os.homedir(), '.codex');
 const SESSIONS_DIR = path.join(CODEX_DIR, 'sessions');
 
 // Type for directory entries from readdirSync with withFileTypes: true
-type Dirent = { name: string; isDirectory(): boolean; isFile(): boolean; isSymlink(): boolean };
+type Dirent = { name: string; isDirectory(): boolean; isFile(): boolean };
 
 // ─── Utility ─────────────────────────────────────────────
 
@@ -230,7 +232,7 @@ async function scanRecentRollouts(activeThresholdMs: number) {
               try {
                 const rolloutFiles = (await fs.promises.readdir(dayDir))
                   .filter((f: string) => f.startsWith('rollout-') && f.endsWith('.jsonl'));
-                const fileResults = await Promise.all(rolloutFiles.map(async (file: string) => {
+                const fileResults = await Promise.all(rolloutFiles.map(async (file: string): Promise<ScanResult | null> => {
                   const filePath = path.join(dayDir, file);
                   try {
                     const stat = await fs.promises.stat(filePath);
@@ -241,21 +243,21 @@ async function scanRecentRollouts(activeThresholdMs: number) {
                     return null;
                   }
                 }));
-                return fileResults.filter(Boolean);
+                return fileResults.filter((result): result is ScanResult => result !== null);
               } catch (err) {
                 debugAdapterError('codex', 'scanRecentRollouts readdir day', err, dayDir);
                 return [];
               }
             }));
 
-            return dayResults.flat();
+            return dayResults.flat() as ScanResult[];
           } catch (err) {
             debugAdapterError('codex', 'scanRecentRollouts readdir month', err, monthDir);
             return [];
           }
         }));
 
-        return monthResults.flat();
+        return monthResults.flat() as ScanResult[];
       } catch (err) {
         debugAdapterError('codex', 'scanRecentRollouts readdir year', err, yearDir);
         return [];
@@ -274,7 +276,7 @@ async function scanRecentRollouts(activeThresholdMs: number) {
 
 // ─── Adapter class ────────────────────────────────────
 
-class CodexAdapter {
+export class CodexAdapter implements AgentAdapter {
   get name() { return 'Codex CLI'; }
   get provider() { return 'codex'; }
   get homeDir() { return CODEX_DIR; }
@@ -337,13 +339,11 @@ class CodexAdapter {
     return { toolHistory: [], messages: [] };
   }
 
-  getWatchPaths() {
-    const paths = [];
+  getWatchPaths(): WatchPath[] {
+    const paths: WatchPath[] = [];
     if (fs.existsSync(SESSIONS_DIR)) {
       paths.push({ type: 'directory', path: SESSIONS_DIR, recursive: true, filter: '.jsonl' });
     }
     return paths;
   }
 }
-
-module.exports = { CodexAdapter };

--- a/claudeville/adapters/copilot.ts
+++ b/claudeville/adapters/copilot.ts
@@ -10,16 +10,18 @@
  *   {"type":"user.message","data":{"content":"..."}}
  *   {"type":"assistant.message","data":{"content":[{"type":"text","text":"..."}],...}}
  */
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-const { debugAdapterError, readLines, parseJsonLines } = require('./jsonl-utils');
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import type { AgentAdapter, WatchPath } from '../../shared/types.js';
+import { debugAdapterError, readLines, parseJsonLines } from './jsonl-utils.js';
 
 const COPILOT_DIR = path.join(os.homedir(), '.copilot');
 const SESSION_STATE_DIR = path.join(COPILOT_DIR, 'session-state');
 
 // Type for directory entries from readdirSync with withFileTypes: true
-type Dirent = { name: string; isDirectory(): boolean; isFile(): boolean; isSymlink(): boolean };
+type Dirent = { name: string; isDirectory(): boolean; isFile(): boolean };
 
 // ─── Utility ─────────────────────────────────────────────
 
@@ -199,7 +201,7 @@ async function scanAllSessions(activeThresholdMs: number) {
   try {
     const sessionDirs = (await fs.promises.readdir(SESSION_STATE_DIR, { withFileTypes: true }))
       .filter((d: Dirent) => d.isDirectory());
-    const dirResults = await Promise.all(sessionDirs.map(async (sessionDir: Dirent) => {
+    const dirResults = await Promise.all(sessionDirs.map(async (sessionDir: Dirent): Promise<ScanResult | null> => {
       const eventsFile = path.join(SESSION_STATE_DIR, sessionDir.name, 'events.jsonl');
       if (!fs.existsSync(eventsFile)) return null;
 
@@ -217,7 +219,7 @@ async function scanAllSessions(activeThresholdMs: number) {
       }
     }));
 
-    results.push(...dirResults.filter(Boolean));
+    results.push(...dirResults.filter((result): result is ScanResult => result !== null));
   } catch (err) {
     debugAdapterError('copilot', 'scanAllSessions', err, SESSION_STATE_DIR);
   }
@@ -227,7 +229,7 @@ async function scanAllSessions(activeThresholdMs: number) {
 
 // ─── Adapter class ─────────────────────────────────────
 
-class CopilotAdapter {
+export class CopilotAdapter implements AgentAdapter {
   get name() { return 'GitHub Copilot'; }
   get provider() { return 'copilot'; }
   get homeDir() { return COPILOT_DIR; }
@@ -284,12 +286,10 @@ class CopilotAdapter {
     return { toolHistory: [], messages: [] };
   }
 
-  getWatchPaths() {
+  getWatchPaths(): WatchPath[] {
     if (fs.existsSync(SESSION_STATE_DIR)) {
       return [{ type: 'directory', path: SESSION_STATE_DIR, recursive: true, filter: 'events.jsonl' }];
     }
     return [];
   }
 }
-
-module.exports = { CopilotAdapter };

--- a/claudeville/adapters/gemini.ts
+++ b/claudeville/adapters/gemini.ts
@@ -16,16 +16,18 @@
  * Project path restoration: projectHash is SHA-256 of cwd, so
  * map by computing hashes of known project paths
  */
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-const crypto = require('crypto');
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import crypto from 'crypto';
+
+import type { AgentAdapter, WatchPath } from '../../shared/types.js';
 
 const GEMINI_DIR = path.join(os.homedir(), '.gemini');
 const TMP_DIR = path.join(GEMINI_DIR, 'tmp');
 
 // Type for directory entries from readdirSync with withFileTypes: true
-type Dirent = { name: string; isDirectory(): boolean; isFile(): boolean; isSymlink(): boolean };
+type Dirent = { name: string; isDirectory(): boolean; isFile(): boolean };
 
 // ─── Project path restoration ──────────────────────────────
 
@@ -283,7 +285,7 @@ async function scanActiveSessions(activeThresholdMs: number) {
       try {
         const sessionFiles = await fs.promises.readdir(chatsDir);
         const jsonFiles = sessionFiles.filter((f: string) => f.startsWith('session-') && f.endsWith('.json'));
-        const fileResults = await Promise.all(jsonFiles.map(async (file: string) => {
+        const fileResults = await Promise.all(jsonFiles.map(async (file: string): Promise<ScanResult | null> => {
           const filePath = path.join(chatsDir, file);
           try {
             const stat = await fs.promises.stat(filePath);
@@ -298,14 +300,14 @@ async function scanActiveSessions(activeThresholdMs: number) {
             return null;
           }
         }));
-        return fileResults.filter(Boolean);
+        return fileResults.filter((result): result is ScanResult => result !== null);
       } catch {
         return [];
       }
     }));
 
     for (const group of projectResults) {
-      results.push(...group);
+      results.push(...(group as ScanResult[]));
     }
   } catch { /* ignore */ }
 
@@ -314,7 +316,7 @@ async function scanActiveSessions(activeThresholdMs: number) {
 
 // ─── Adapter class ────────────────────────────────────
 
-class GeminiAdapter {
+export class GeminiAdapter implements AgentAdapter {
   get name() { return 'Gemini CLI'; }
   get provider() { return 'gemini'; }
   get homeDir() { return GEMINI_DIR; }
@@ -376,8 +378,8 @@ class GeminiAdapter {
     return { toolHistory: [], messages: [] };
   }
 
-  getWatchPaths() {
-    const paths = [];
+  getWatchPaths(): WatchPath[] {
+    const paths: WatchPath[] = [];
     if (fs.existsSync(TMP_DIR)) {
       try {
         const projDirs = fs.readdirSync(TMP_DIR, { withFileTypes: true })
@@ -393,5 +395,3 @@ class GeminiAdapter {
     return paths;
   }
 }
-
-module.exports = { GeminiAdapter };

--- a/claudeville/adapters/index.ts
+++ b/claudeville/adapters/index.ts
@@ -2,19 +2,20 @@
  * Adapter registry
  * Registers and manages all AI coding CLI adapters
  */
-const { estimateCost } = require('../../shared/cost.ts');
-const { normalizeTokens } = require('../../shared/session-utils.js');
-const { debugAdapterError } = require('./jsonl-utils');
-const { sanitizeSessionDetail, sanitizeSessionSummary } = require('./sanitize.ts');
-const { ClaudeAdapter } = require('./claude.ts');
-const { CodexAdapter } = require('./codex.ts');
-const { GeminiAdapter } = require('./gemini.ts');
-const { OpenClawAdapter } = require('./openclaw.ts');
-const { CopilotAdapter } = require('./copilot.ts');
-const { VSCodeAdapter } = require('./vscode.ts');
-const { PiAdapter } = require('./pi.ts');
+import { estimateCost } from '../../shared/cost.js';
+import { normalizeTokens } from '../../shared/session-utils.js';
+import type { AdapterSessionDetail, AgentAdapter, AgentSessionSummary, WatchPath } from '../../shared/types.js';
+import { debugAdapterError } from './jsonl-utils.js';
+import { sanitizeSessionDetail, sanitizeSessionSummary } from './sanitize.js';
+import { ClaudeAdapter } from './claude.js';
+import { CodexAdapter } from './codex.js';
+import { GeminiAdapter } from './gemini.js';
+import { OpenClawAdapter } from './openclaw.js';
+import { CopilotAdapter } from './copilot.js';
+import { VSCodeAdapter } from './vscode.js';
+import { PiAdapter } from './pi.js';
 
-const adapters = [
+export const adapters: AgentAdapter[] = [
   new ClaudeAdapter(),
   new CodexAdapter(),
   new GeminiAdapter(),
@@ -27,15 +28,15 @@ const adapters = [
 /**
  * Collect sessions from all active adapters
  */
-async function getAllSessions(activeThresholdMs: number) {
+export async function getAllSessions(activeThresholdMs: number) {
   const adapterResults = await Promise.all(adapters.map(async (adapter) => {
     if (!adapter.isAvailable()) return [];
     try {
       const sessions = await adapter.getActiveSessions(activeThresholdMs);
-      return await Promise.all(sessions.map(async (session: any) => {
+      return await Promise.all(sessions.map(async (session: AgentSessionSummary) => {
         const detailRaw = session.detail || await adapter.getSessionDetail(session.sessionId, session.project, session.filePath);
         const detail = sanitizeSessionDetail(detailRaw || {});
-        const tokens = normalizeTokens(detailRaw?.tokenUsage, session.tokens || null);
+        const tokens = normalizeTokens(detailRaw?.tokenUsage ?? null, session.tokens || null);
 
         const sanitizedSession = sanitizeSessionSummary(session);
 
@@ -59,7 +60,7 @@ async function getAllSessions(activeThresholdMs: number) {
 /**
  * Get session detail for a specific provider
  */
-async function getSessionDetailByProvider(provider: string, sessionId: string, project: string | null) {
+export async function getSessionDetailByProvider(provider: string, sessionId: string, project: string | null): Promise<AdapterSessionDetail> {
   const adapter = adapters.find(a => a.provider === provider);
   if (!adapter) return { toolHistory: [], messages: [] };
   try {
@@ -74,8 +75,8 @@ async function getSessionDetailByProvider(provider: string, sessionId: string, p
 /**
  * Collect all watch paths from active adapters
  */
-function getAllWatchPaths() {
-  const paths = [];
+export function getAllWatchPaths(): WatchPath[] {
+  const paths: WatchPath[] = [];
   for (const adapter of adapters) {
     if (!adapter.isAvailable()) continue;
     try {
@@ -90,18 +91,10 @@ function getAllWatchPaths() {
 /**
  * List active adapters
  */
-function getActiveProviders() {
+export function getActiveProviders() {
   return adapters.filter(a => a.isAvailable()).map(a => ({
     name: a.name,
     provider: a.provider,
     homeDir: a.homeDir,
   }));
 }
-
-module.exports = {
-  adapters,
-  getAllSessions,
-  getSessionDetailByProvider,
-  getAllWatchPaths,
-  getActiveProviders,
-};

--- a/claudeville/adapters/jsonl-utils.js
+++ b/claudeville/adapters/jsonl-utils.js
@@ -3,9 +3,13 @@
  * readLines + parseJsonLines are duplicated verbatim in openclaw, copilot, codex, vscode.
  * Extract once; adapters import from here.
  */
-const fs = require('fs');
+import fs from 'fs';
 
-function debugAdapterError(scope, operation, err, context = '') {
+/**
+ * @typedef {{ from?: 'start' | 'end'; count?: number; scope?: string }} ReadLinesOptions
+ */
+
+export function debugAdapterError(scope, operation, err, context = '') {
   if (!process.env.DEBUG) return;
 
   const message = err instanceof Error ? err.message : String(err);
@@ -16,10 +20,10 @@ function debugAdapterError(scope, operation, err, context = '') {
 /**
  * Read the last N (or first N) lines of a file as strings.
  * @param {string} filePath
- * @param {{ from: 'start'|'end', count: number }} options
+ * @param {ReadLinesOptions} options
  * @returns {Promise<string[]>}
  */
-async function readLines(filePath, { from = 'end', count = 50, scope = 'jsonl-utils' } = {}) {
+export async function readLines(filePath, { from = 'end', count = 50, scope = 'jsonl-utils' } = {}) {
   try {
     if (!fs.existsSync(filePath)) return [];
     const content = await fs.promises.readFile(filePath, 'utf-8');
@@ -35,9 +39,9 @@ async function readLines(filePath, { from = 'end', count = 50, scope = 'jsonl-ut
 /**
  * Parse an array of JSONL strings into objects, skipping bad lines.
  * @param {string[]} lines
- * @returns {object[]}
+ * @returns {any[]}
  */
-function parseJsonLines(lines, scope = 'jsonl-utils') {
+export function parseJsonLines(lines, scope = 'jsonl-utils') {
   const results = [];
   for (const line of lines) {
     if (!line.trim()) continue;
@@ -47,5 +51,3 @@ function parseJsonLines(lines, scope = 'jsonl-utils') {
   }
   return results;
 }
-
-module.exports = { debugAdapterError, readLines, parseJsonLines };

--- a/claudeville/adapters/openclaw.ts
+++ b/claudeville/adapters/openclaw.ts
@@ -7,16 +7,18 @@
  *   {"type":"model_change","provider":"github-copilot","modelId":"gpt-5-mini",...}
  *   {"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"..."}],"model":"...","usage":{...}},...}
  */
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-const { debugAdapterError, readLines, parseJsonLines } = require('./jsonl-utils');
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import type { AgentAdapter, WatchPath } from '../../shared/types.js';
+import { debugAdapterError, readLines, parseJsonLines } from './jsonl-utils.js';
 
 const OPENCLAW_DIR = path.join(os.homedir(), '.openclaw');
 const AGENTS_DIR = path.join(OPENCLAW_DIR, 'agents');
 
 // Type for directory entries from readdirSync with withFileTypes: true
-type Dirent = { name: string; isDirectory(): boolean; isFile(): boolean; isSymlink(): boolean };
+type Dirent = { name: string; isDirectory(): boolean; isFile(): boolean };
 
 // ─── Utility ─────────────────────────────────────────────
 
@@ -257,7 +259,7 @@ async function scanAllSessionFiles(activeThresholdMs: number): Promise<OpenClawS
 
 // ─── Adapter class ─────────────────────────────────────
 
-class OpenClawAdapter {
+export class OpenClawAdapter implements AgentAdapter {
   get name() { return 'OpenClaw'; }
   get provider() { return 'openclaw'; }
   get homeDir() { return OPENCLAW_DIR; }
@@ -321,8 +323,8 @@ class OpenClawAdapter {
     return { toolHistory: [], messages: [] };
   }
 
-  getWatchPaths(): Array<{ type: string; path: string; recursive?: boolean; filter?: string }> {
-    const paths: Array<{ type: string; path: string; recursive?: boolean; filter?: string }> = [];
+  getWatchPaths(): WatchPath[] {
+    const paths: WatchPath[] = [];
     if (!fs.existsSync(AGENTS_DIR)) return paths;
 
     try {
@@ -342,5 +344,3 @@ class OpenClawAdapter {
     return paths;
   }
 }
-
-module.exports = { OpenClawAdapter };

--- a/claudeville/adapters/pi.ts
+++ b/claudeville/adapters/pi.ts
@@ -8,21 +8,23 @@
  *   {"type":"message","message":{"role":"user","content":[{"type":"text","text":"..."}]}}
  *   {"type":"message","message":{"role":"assistant","content":[{"type":"toolCall","name":"bash","arguments":{...}}],"usage":{...}}}
  */
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-const { debugAdapterError, readLines, parseJsonLines } = require('./jsonl-utils');
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import type { AgentAdapter, WatchPath } from '../../shared/types.js';
+import { debugAdapterError, readLines, parseJsonLines } from './jsonl-utils.js';
 
 const PI_DIR = path.join(os.homedir(), '.pi');
 const SESSIONS_DIR = path.join(PI_DIR, 'agent', 'sessions');
 
-type Dirent = { name: string; isDirectory(): boolean; isFile(): boolean; isSymlink(): boolean };
+type Dirent = { name: string; isDirectory(): boolean; isFile(): boolean };
 
 // ─── Utility ─────────────────────────────────────────────
 
 // ─── Session parsing ──────────────────────────────────────
 
-async function parseSession(filePath: string) {
+export async function parseSession(filePath: string) {
   const detail: {
     model: string | null;
     provider: string | null;
@@ -202,7 +204,7 @@ function parseSessionId(sessionId: string) {
   };
 }
 
-function projectDirToPath(projectDir: string) {
+export function projectDirToPath(projectDir: string) {
   // Convert --Users-openclaw-Github-claude-ville-- back to /Users/openclaw/Github/claude-ville
   return projectDir
     .replace(/^--/, '/')
@@ -210,7 +212,7 @@ function projectDirToPath(projectDir: string) {
     .replace(/-/g, '/');
 }
 
-function resolveProjectPath(detail: { project: string | null }, projectDir: string) {
+export function resolveProjectPath(detail: { project: string | null }, projectDir: string) {
   return detail.project || projectDirToPath(projectDir);
 }
 
@@ -273,7 +275,7 @@ async function scanAllSessionFiles(activeThresholdMs: number): Promise<ScanResul
 
 // ─── Adapter class ─────────────────────────────────────
 
-class PiAdapter {
+export class PiAdapter implements AgentAdapter {
   get name() { return 'Pi Coding Agent'; }
   get provider() { return 'pi'; }
   get homeDir() { return PI_DIR; }
@@ -338,8 +340,8 @@ class PiAdapter {
     return { toolHistory: [], messages: [] };
   }
 
-  getWatchPaths(): Array<{ type: string; path: string; recursive?: boolean; filter?: string }> {
-    const paths: Array<{ type: string; path: string; recursive?: boolean; filter?: string }> = [];
+  getWatchPaths(): WatchPath[] {
+    const paths: WatchPath[] = [];
     if (!fs.existsSync(SESSIONS_DIR)) return paths;
 
     try {
@@ -351,5 +353,3 @@ class PiAdapter {
     return paths;
   }
 }
-
-module.exports = { PiAdapter, parseSession, projectDirToPath, resolveProjectPath };

--- a/claudeville/adapters/sanitize.ts
+++ b/claudeville/adapters/sanitize.ts
@@ -4,18 +4,18 @@
  * - Provider parsers keep raw data; this layer cleans it for display
  */
 
-function normalizeWhitespace(value: unknown) {
+export function normalizeWhitespace(value: unknown) {
   return String(value || '')
     .replace(/\r\n/g, '\n')
     .replace(/\s+/g, ' ')
     .trim();
 }
 
-function summarizeText(value: unknown, maxLen = 200) {
+export function summarizeText(value: unknown, maxLen = 200) {
   return normalizeWhitespace(value).substring(0, maxLen);
 }
 
-function looksLikeNoise(text: unknown) {
+export function looksLikeNoise(text: unknown) {
   if (!text) return true;
 
   // Match only complete status-line patterns that never appear in real user messages.
@@ -34,13 +34,13 @@ function looksLikeNoise(text: unknown) {
   return patterns.some((re) => re.test(String(text)));
 }
 
-function cleanText(value: unknown, maxLen = 200) {
+export function cleanText(value: unknown, maxLen = 200) {
   const text = summarizeText(value, maxLen);
   if (!text || looksLikeNoise(text)) return '';
   return text;
 }
 
-function sanitizeToolHistory(toolHistory: Array<{ tool?: unknown; detail?: unknown }> = []) {
+export function sanitizeToolHistory(toolHistory: Array<{ tool?: unknown; detail?: unknown }> = []) {
   if (!Array.isArray(toolHistory)) return [];
 
   return toolHistory
@@ -52,7 +52,7 @@ function sanitizeToolHistory(toolHistory: Array<{ tool?: unknown; detail?: unkno
     .filter((item) => item.tool || item.detail);
 }
 
-function sanitizeMessages(messages: Array<{ text?: unknown }> = []) {
+export function sanitizeMessages(messages: Array<{ text?: unknown }> = []) {
   if (!Array.isArray(messages)) return [];
 
   return messages
@@ -63,7 +63,7 @@ function sanitizeMessages(messages: Array<{ text?: unknown }> = []) {
     .filter((msg) => msg.text);
 }
 
-function sanitizeSessionDetail(detail: any = {}) {
+export function sanitizeSessionDetail(detail: any = {}) {
   return {
     ...detail,
     toolHistory: sanitizeToolHistory(detail?.toolHistory || []),
@@ -71,7 +71,7 @@ function sanitizeSessionDetail(detail: any = {}) {
   };
 }
 
-function sanitizeSessionSummary(session: any = {}) {
+export function sanitizeSessionSummary(session: any = {}) {
   return {
     ...session,
     rawLastMessage: session?.lastMessage ?? null,
@@ -80,10 +80,3 @@ function sanitizeSessionSummary(session: any = {}) {
     lastToolInput: summarizeText(session?.lastToolInput || '', 80) || null,
   };
 }
-
-module.exports = {
-  cleanText,
-  sanitizeSessionDetail,
-  sanitizeSessionSummary,
-  summarizeText,
-};

--- a/claudeville/adapters/vscode.ts
+++ b/claudeville/adapters/vscode.ts
@@ -4,10 +4,12 @@
  *   ~/Library/Application Support/Code/User/workspaceStorage/<workspaceId>/GitHub.copilot-chat/debug-logs/<sessionId>/main.jsonl
  *   ~/Library/Application Support/Code - Insiders/User/workspaceStorage/<workspaceId>/GitHub.copilot-chat/debug-logs/<sessionId>/main.jsonl
  */
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-const { debugAdapterError, readLines, parseJsonLines } = require('./jsonl-utils');
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import type { AgentAdapter, WatchPath } from '../../shared/types.js';
+import { debugAdapterError, readLines, parseJsonLines } from './jsonl-utils.js';
 
 const VSCODE_USER_DIR = process.env.VSCODE_USER_DATA_DIR
   || path.join(os.homedir(), 'Library', 'Application Support', 'Code', 'User');
@@ -19,7 +21,7 @@ const STORAGE_ROOTS = [
   { channel: 'vscode-insiders', workspaceStorageDir: path.join(VSCODE_INSIDERS_USER_DIR, 'workspaceStorage') },
 ];
 
-type Dirent = { name: string; isDirectory(): boolean; isFile(): boolean; isSymlink(): boolean };
+type Dirent = { name: string; isDirectory(): boolean; isFile(): boolean };
 
 const DEFAULT_MIN_ACTIVE_WINDOW_MS = 30 * 60 * 1000;
 const MIN_ACTIVE_WINDOW_MS = Math.max(
@@ -33,8 +35,19 @@ const SOURCE_PRIORITY = {
   resource: 1,
 };
 
-function shouldReplaceCandidate(existing: { sourceType: string; mtime: number } | null, incoming: { sourceType: string; mtime: number }): boolean {
+type ResourceSessionCandidate = {
+  channel: string;
+  workspaceId: string;
+  rawSessionId: string;
+  sourceType: 'debug' | 'transcript' | 'resource';
+  filePath: string;
+  project: string;
+  mtime: number;
+};
+
+function shouldReplaceCandidate(existing: { sourceType: string; mtime: number } | null | undefined, incoming: { sourceType: string; mtime: number } | null | undefined): boolean {
   if (!existing) return true;
+  if (!incoming) return false;
   const existingPriority = SOURCE_PRIORITY[existing.sourceType as keyof typeof SOURCE_PRIORITY] || 0;
   const incomingPriority = SOURCE_PRIORITY[incoming.sourceType as keyof typeof SOURCE_PRIORITY] || 0;
 
@@ -60,7 +73,7 @@ async function scanResourceSessionContents(filePath: string): Promise<Array<{ ca
   const sessionRoot = getResourceSessionRoot(filePath);
   if (!sessionRoot || !fs.existsSync(sessionRoot)) return [];
 
-  let entries = [];
+  let entries: Array<{ callId: string; filePath: string; text: string; ts: number }> = [];
   try {
     const children = await fs.promises.readdir(sessionRoot, { withFileTypes: true });
     const contentRows = await Promise.all(children
@@ -85,7 +98,7 @@ async function scanResourceSessionContents(filePath: string): Promise<Array<{ ca
         }
       }));
 
-    entries = contentRows.filter(Boolean).sort((a, b) => a.ts - b.ts);
+    entries = contentRows.filter((item): item is { callId: string; filePath: string; text: string; ts: number } => item !== null).sort((a, b) => a.ts - b.ts);
   } catch (err) {
     debugAdapterError('vscode', 'scanResourceSessionContents', err, sessionRoot);
     entries = [];
@@ -349,12 +362,12 @@ function parseSessionId(sessionId: string): { channel: string; workspaceId: stri
 async function scanAllSessions(activeThresholdMs: number) {
   const now = Date.now();
   const effectiveThresholdMs = Math.max(Number(activeThresholdMs || 0), MIN_ACTIVE_WINDOW_MS);
-  const results = [];
+  const results: ResourceSessionCandidate[] = [];
 
   for (const root of STORAGE_ROOTS) {
     if (!fs.existsSync(root.workspaceStorageDir)) continue;
 
-    let workspaceDirs = [];
+    let workspaceDirs: Dirent[] = [];
     try {
       workspaceDirs = await fs.promises.readdir(root.workspaceStorageDir, { withFileTypes: true });
     } catch (err) {
@@ -364,19 +377,19 @@ async function scanAllSessions(activeThresholdMs: number) {
 
     const entries = await Promise.all(workspaceDirs
       .filter((d: Dirent) => d.isDirectory())
-      .map(async (workspaceDir: Dirent) => {
+      .map(async (workspaceDir: Dirent): Promise<ResourceSessionCandidate[]> => {
         const workspaceId = workspaceDir.name;
         const workspacePath = path.join(root.workspaceStorageDir, workspaceId);
         const copilotChatDir = path.join(workspacePath, 'GitHub.copilot-chat');
         if (!fs.existsSync(copilotChatDir)) return [];
 
         const projectPath = await readWorkspacePath(workspacePath);
-        const candidates = [];
+        const candidates: ResourceSessionCandidate[] = [];
 
         // legacy/new debug logs
         const debugLogsDir = path.join(copilotChatDir, 'debug-logs');
         if (fs.existsSync(debugLogsDir)) {
-          let debugLogDirs = [];
+          let debugLogDirs: Dirent[] = [];
           try {
             debugLogDirs = await fs.promises.readdir(debugLogsDir, { withFileTypes: true });
           } catch (err) {
@@ -386,7 +399,7 @@ async function scanAllSessions(activeThresholdMs: number) {
 
           const debugEntries = await Promise.all(debugLogDirs
             .filter((d: Dirent) => d.isDirectory())
-            .map(async (logDir: Dirent) => {
+            .map(async (logDir: Dirent): Promise<ResourceSessionCandidate | null> => {
               const mainLogFile = path.join(debugLogsDir, logDir.name, 'main.jsonl');
               if (!fs.existsSync(mainLogFile)) return null;
 
@@ -408,13 +421,13 @@ async function scanAllSessions(activeThresholdMs: number) {
               }
             }));
 
-          candidates.push(...debugEntries.filter(Boolean));
+          candidates.push(...debugEntries.filter((item): item is ResourceSessionCandidate => item !== null));
         }
 
         // transcript jsonl
         const transcriptsDir = path.join(copilotChatDir, 'transcripts');
         if (fs.existsSync(transcriptsDir)) {
-          let transcriptFiles = [];
+          let transcriptFiles: string[] = [];
           try {
             transcriptFiles = await fs.promises.readdir(transcriptsDir);
           } catch (err) {
@@ -424,7 +437,7 @@ async function scanAllSessions(activeThresholdMs: number) {
 
           const transcriptEntries = await Promise.all(transcriptFiles
             .filter((f: string) => f.endsWith('.jsonl'))
-            .map(async (file: string) => {
+            .map(async (file: string): Promise<ResourceSessionCandidate | null> => {
               const transcriptPath = path.join(transcriptsDir, file);
               try {
                 const stat = await fs.promises.stat(transcriptPath);
@@ -445,13 +458,13 @@ async function scanAllSessions(activeThresholdMs: number) {
               }
             }));
 
-          candidates.push(...transcriptEntries.filter(Boolean));
+          candidates.push(...transcriptEntries.filter((item): item is ResourceSessionCandidate => item !== null));
         }
 
         // live chat resources (often newest while a turn is running)
         const resourcesDir = path.join(copilotChatDir, 'chat-session-resources');
         if (fs.existsSync(resourcesDir)) {
-          let sessionDirs = [];
+          let sessionDirs: Dirent[] = [];
           try {
             sessionDirs = await fs.promises.readdir(resourcesDir, { withFileTypes: true });
           } catch (err) {
@@ -461,9 +474,9 @@ async function scanAllSessions(activeThresholdMs: number) {
 
           const resourceEntries = await Promise.all(sessionDirs
             .filter((d: Dirent) => d.isDirectory())
-            .map(async (sessionDir: Dirent) => {
+            .map(async (sessionDir: Dirent): Promise<ResourceSessionCandidate | null> => {
               const sessionRoot = path.join(resourcesDir, sessionDir.name);
-              let toolDirs = [];
+              let toolDirs: Dirent[] = [];
               try {
                 toolDirs = await fs.promises.readdir(sessionRoot, { withFileTypes: true });
               } catch (err) {
@@ -485,7 +498,7 @@ async function scanAllSessions(activeThresholdMs: number) {
               });
 
               const stats = await Promise.all(statPromises);
-              let newest = null;
+              let newest: { filePath: string; mtime: number } | null = null;
               for (const stat of stats) {
                 if (stat && (!newest || stat.mtime > newest.mtime)) {
                   newest = stat;
@@ -506,15 +519,17 @@ async function scanAllSessions(activeThresholdMs: number) {
               };
             }));
 
-          candidates.push(...resourceEntries.filter(Boolean));
+          candidates.push(...resourceEntries.filter((item): item is ResourceSessionCandidate => item !== null));
         }
         // dedupe by raw session key, keep newest source
-        const bySession = new Map();
+        const bySession = new Map<string, ResourceSessionCandidate>();
         for (const item of candidates) {
-          const key = `${item.channel}:${item.workspaceId}:${item.rawSessionId}`;
+          const candidate = item;
+          if (!candidate) continue;
+          const key = `${candidate.channel}:${candidate.workspaceId}:${candidate.rawSessionId}`;
           const existing = bySession.get(key);
-          if (shouldReplaceCandidate(existing, item)) {
-            bySession.set(key, item);
+          if (shouldReplaceCandidate(existing, candidate ?? null)) {
+            bySession.set(key, candidate);
           }
         }
 
@@ -529,7 +544,7 @@ async function scanAllSessions(activeThresholdMs: number) {
   return results;
 }
 
-class VSCodeAdapter {
+export class VSCodeAdapter implements AgentAdapter {
   get name() { return 'VS Code Copilot Chat'; }
   get provider() { return 'vscode'; }
   get homeDir() { return `${VSCODE_USER_DIR} | ${VSCODE_INSIDERS_USER_DIR}`; }
@@ -591,8 +606,8 @@ class VSCodeAdapter {
     };
   }
 
-  getWatchPaths() {
-    const paths = [];
+  getWatchPaths(): WatchPath[] {
+    const paths: WatchPath[] = [];
     for (const root of STORAGE_ROOTS) {
       if (!fs.existsSync(root.workspaceStorageDir)) continue;
       paths.push({
@@ -611,5 +626,3 @@ class VSCodeAdapter {
     return paths;
   }
 }
-
-module.exports = { VSCodeAdapter };

--- a/claudeville/server.ts
+++ b/claudeville/server.ts
@@ -1,41 +1,39 @@
-require('../load-local-env.ts');
+import '../load-local-env.js';
 
 import * as http from 'http';
 import * as net from 'net';
 import * as fs from 'fs';
 import * as path from 'path';
-const { buildRuntimeConfig } = require('../runtime-config.shared');
+import { fileURLToPath } from 'url';
 
-type HttpRequest = http.IncomingMessage;
-type HttpResponse = http.ServerResponse;
-
-// ─── Adapter load ─────────────────────────────────────
-const {
+import { buildRuntimeConfig } from '../runtime-config.shared.js';
+import { MIME_TYPES } from '../shared/mime-types.js';
+import { setCorsHeaders, sendJson, sendError, safeLimit } from '../shared/http-utils.js';
+import { createWebSocketFrame, computeAcceptKey } from '../shared/ws-utils.js';
+import { createFileWatchers } from '../shared/watch-utils.js';
+import { DISCONNECTED_CODES } from '../shared/ws-helpers.js';
+import {
+  adapters,
   getAllSessions,
   getSessionDetailByProvider,
   getAllWatchPaths,
   getActiveProviders,
-  adapters,
-} = require('./adapters');
+} from './adapters/index.js';
+import * as usageQuota from './services/usageQuota.js';
 
-// ─── Usage Quota service ──────────────────────────────
-const usageQuota = require('./services/usageQuota');
-
-const { setCorsHeaders, sendJson, sendError, safeLimit } = require('../shared/http-utils');
-const { createWebSocketFrame, computeAcceptKey } = require('../shared/ws-utils');
-const { createFileWatchers } = require('../shared/watch-utils');
-const { DISCONNECTED_CODES } = require('../shared/ws-helpers');
+type HttpRequest = http.IncomingMessage;
+type HttpResponse = http.ServerResponse;
 
 // Claude adapter (teams/tasks are Claude-only)
 const claudeAdapter = adapters.find((a: { provider: string }) => a.provider === 'claude');
 
 // ─── Config ────────────────────────────────────────────────
 const PORT = Number(process.env.PORT || 4000);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 const BUILT_FRONTEND_DIR = path.join(__dirname, '..', 'dist', 'frontend');
 const STATIC_DIR = fs.existsSync(path.join(BUILT_FRONTEND_DIR, 'index.html')) ? BUILT_FRONTEND_DIR : __dirname;
 const ACTIVE_THRESHOLD_MS = 2 * 60 * 1000; // 2 minutes
-
-const { MIME_TYPES } = require('../shared/mime-types');
 
 // ─── WebSocket client management ──────────────────────────
 const wsClients = new Set<net.Socket>();
@@ -62,7 +60,7 @@ async function handleGetSessions(req: HttpRequest, res: HttpResponse) {
  */
 async function handleGetTeams(req: HttpRequest, res: HttpResponse) {
   try {
-    const teams = claudeAdapter ? await claudeAdapter.getTeams() : [];
+    const teams = claudeAdapter?.getTeams ? await claudeAdapter.getTeams() : [];
     sendJson(res, 200, { teams, count: teams.length });
   } catch (err: unknown) {
     console.error('team query failed:', err instanceof Error ? err.message : String(err));
@@ -76,7 +74,7 @@ async function handleGetTeams(req: HttpRequest, res: HttpResponse) {
  */
 async function handleGetTasks(req: HttpRequest, res: HttpResponse) {
   try {
-    const taskGroups = claudeAdapter ? await claudeAdapter.getTasks() : [];
+    const taskGroups = claudeAdapter?.getTasks ? await claudeAdapter.getTasks() : [];
     sendJson(res, 200, { taskGroups, totalGroups: taskGroups.length });
   } catch (err: unknown) {
     console.error('task query failed:', err instanceof Error ? err.message : String(err));
@@ -194,7 +192,7 @@ function handleStaticFile(req: HttpRequest, res: HttpResponse) {
     }
 
     const ext = path.extname(filePath).toLowerCase();
-    const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+    const contentType = MIME_TYPES[ext as keyof typeof MIME_TYPES] || 'application/octet-stream';
     const isText = contentType.includes('text') ||
                    contentType.includes('javascript') ||
                    contentType.includes('json') ||
@@ -435,7 +433,7 @@ async function sendInitialData(socket: net.Socket) {
   try {
     const [sessions, teams] = await Promise.all([
       getAllSessions(ACTIVE_THRESHOLD_MS),
-      claudeAdapter ? claudeAdapter.getTeams() : [],
+      claudeAdapter?.getTeams ? claudeAdapter.getTeams() : [],
     ]);
     wsSend(socket, {
       type: 'init',
@@ -463,7 +461,7 @@ async function broadcastUpdate() {
   try {
     const [sessions, teams] = await Promise.all([
       getAllSessions(ACTIVE_THRESHOLD_MS),
-      claudeAdapter ? claudeAdapter.getTeams() : [],
+      claudeAdapter?.getTeams ? claudeAdapter.getTeams() : [],
     ]);
     wsBroadcast({
       type: 'update',
@@ -541,7 +539,7 @@ const server = http.createServer((req: HttpRequest, res: HttpResponse) => {
     if (fs.existsSync(widgetFile)) {
       const ext = path.extname(widgetFile).toLowerCase();
       setCorsHeaders(res);
-      res.writeHead(200, { 'Content-Type': MIME_TYPES[ext], 'Cache-Control': 'no-cache' });
+      res.writeHead(200, { 'Content-Type': MIME_TYPES[ext as keyof typeof MIME_TYPES], 'Cache-Control': 'no-cache' });
       fs.createReadStream(widgetFile, { encoding: 'utf-8' }).pipe(res);
       return;
     }

--- a/claudeville/services/usageQuota.ts
+++ b/claudeville/services/usageQuota.ts
@@ -8,13 +8,14 @@
  *   D) api.anthropic.com/api/oauth/usage → 5h/7d quota (currently unavailable, periodic retries)
  */
 
-const fs = require('fs');
-const path = require('path');
-const { execFile } = require('child_process');
+import fs from 'fs';
+import path from 'path';
+import { execFile } from 'child_process';
+import os from 'os';
 import * as http from 'http';
 import * as https from 'https';
 
-const CLAUDE_HOME = path.join(require('os').homedir(), '.claude');
+const CLAUDE_HOME = path.join(os.homedir(), '.claude');
 const CREDENTIALS_PATH = path.join(CLAUDE_HOME, '.credentials.json');
 const STATS_CACHE_PATH = path.join(CLAUDE_HOME, 'stats-cache.json');
 const HISTORY_PATH = path.join(CLAUDE_HOME, 'history.jsonl');
@@ -226,7 +227,7 @@ function tryFetchQuota() {
 
 // ─── Public API ────────────────────────────────────────────────
 
-function fetchUsage() {
+export function fetchUsage() {
   const credentials = readCredentials();
   const stats = readStats();
 
@@ -254,7 +255,7 @@ function fetchUsage() {
   };
 }
 
-function init() {
+export function init() {
   // Fetch email at server start (async)
   fetchEmail().then(email => {
     if (email) console.log(`[Usage] account: ${email}`);
@@ -264,5 +265,3 @@ function init() {
   // Initial quota API attempt
   tryFetchQuota();
 }
-
-module.exports = { fetchUsage, init };

--- a/claudeville/src/domain/entities/Agent.ts
+++ b/claudeville/src/domain/entities/Agent.ts
@@ -314,9 +314,9 @@ export class Agent {
     _buildDisplaySession() {
         return {
             sessionId: this.id,
-            agentId: this.nameKind === 'agent' ? this.nameSeed : undefined,
-            displayName: this.nameHint ?? undefined,
-            agentName: this.nameHint ?? undefined,
+            agentId: this.nameKind === 'agent' ? this.nameSeed : null,
+            displayName: this.nameHint ?? null,
+            agentName: this.nameHint ?? null,
             provider: this.provider,
             agentType: this.nameKind === 'agent' ? 'sub-agent' : 'main',
         };

--- a/collector/index.ts
+++ b/collector/index.ts
@@ -1,33 +1,16 @@
-require('../load-local-env.ts');
+import '../load-local-env.js';
 
-const { createFileWatchers } = require('../shared/watch-utils');
-const crypto = require('crypto');
-const { adapters, getAllSessions, getAllWatchPaths, getActiveProviders, getSessionDetailByProvider } = require('../claudeville/adapters/index.ts');
+import crypto from 'crypto';
+import os from 'os';
+
+import { createFileWatchers } from '../shared/watch-utils.js';
+import type { WatchPath } from '../shared/types.js';
+import { adapters, getAllSessions, getAllWatchPaths, getActiveProviders, getSessionDetailByProvider } from '../claudeville/adapters/index.js';
 import { buildCollectorSnapshot, normalizeSession } from './snapshot.js';
+import type { CollectorSnapshotDeps } from './snapshot.js';
 import { createCollectorPublisher } from './publisher.js';
 
 const DEFAULT_ACTIVE_THRESHOLD_MS = 2 * 60 * 1000;
-
-type TokenLike = {
-  totalInput?: number;
-  totalOutput?: number;
-  input?: number;
-  output?: number;
-};
-
-type SessionDetail = {
-  tokenUsage?: TokenLike | null;
-};
-
-type SessionSummary = {
-  provider: string;
-  sessionId: string;
-  project?: string;
-  model?: string;
-  tokens?: { input?: number; output?: number } | null;
-  detail?: SessionDetail | null;
-  [key: string]: unknown;
-};
 
 type CollectorRuntimeConfig = {
   hubUrl: string;
@@ -39,17 +22,17 @@ type CollectorRuntimeConfig = {
 };
 
 type CollectorRuntimeDeps = {
-  createFileWatchers: (paths: string[], onChange: () => void) => { watchCount: number };
-  createHash: (algorithm: string) => { update: (data: string) => { digest: (format: string) => string }; digest: (format: string) => string };
+  createFileWatchers: (paths: WatchPath[], onChange: () => void) => { watchCount: number };
+  createHash: typeof crypto.createHash;
   adapters: Array<{
     provider?: string;
     getTeams?: () => Promise<unknown[]> | unknown[];
     getTasks?: () => Promise<unknown[]> | unknown[];
   }>;
-  getAllSessions: (activeThresholdMs: number) => Promise<SessionSummary[]>;
-  getAllWatchPaths: () => string[];
+  getAllSessions: CollectorSnapshotDeps['getAllSessions'];
+  getAllWatchPaths: () => WatchPath[];
   getActiveProviders: () => unknown[];
-  getSessionDetailByProvider: (provider: string, sessionId: string, project?: string) => Promise<SessionDetail | null>;
+  getSessionDetailByProvider: CollectorSnapshotDeps['getSessionDetailByProvider'];
   fetch: typeof fetch;
   setTimeout: typeof globalThis.setTimeout;
   clearTimeout: typeof globalThis.clearTimeout;
@@ -59,17 +42,14 @@ type CollectorRuntimeDeps = {
 };
 
 type SnapshotBuilderDeps = {
-  getAllSessions: (activeThresholdMs: number) => Promise<SessionSummary[]>;
-  getSessionDetailByProvider: (provider: string, sessionId: string, project?: string) => Promise<SessionDetail | null>;
-  getActiveProviders: () => unknown[];
-  claudeAdapter?: {
-    getTeams?: () => Promise<unknown[]> | unknown[];
-    getTasks?: () => Promise<unknown[]> | unknown[];
-  };
+  getAllSessions: CollectorSnapshotDeps['getAllSessions'];
+  getSessionDetailByProvider: CollectorSnapshotDeps['getSessionDetailByProvider'];
+  getActiveProviders: CollectorSnapshotDeps['getActiveProviders'];
+  claudeAdapter?: CollectorSnapshotDeps['claudeAdapter'];
 };
 
 export function getCollectorConfig(): CollectorRuntimeConfig {
-  const hostname = require('os').hostname();
+  const hostname = os.hostname();
   const activeThresholdMs = Number(process.env.COLLECTOR_ACTIVE_THRESHOLD_MS || DEFAULT_ACTIVE_THRESHOLD_MS);
 
   return {
@@ -82,7 +62,7 @@ export function getCollectorConfig(): CollectorRuntimeConfig {
   };
 }
 
-const defaultCollectorDeps: CollectorRuntimeDeps = {
+  const defaultCollectorDeps: CollectorRuntimeDeps = {
   createFileWatchers,
   createHash: crypto.createHash,
   adapters,

--- a/collector/publisher.ts
+++ b/collector/publisher.ts
@@ -1,10 +1,12 @@
+import crypto from 'crypto';
+
 const FLUSH_DELAY_MS = 100;
 
 interface SnapshotWithSessions {
   sessions: Array<unknown>;
 }
 
-export function computeSnapshotFingerprint(snapshot: object, createHash: (algorithm: string) => { update: (data: string) => { digest: (format: string) => string }; digest: (format: string) => string }): string {
+export function computeSnapshotFingerprint(snapshot: object, createHash: typeof crypto.createHash): string {
   return createHash('sha1').update(JSON.stringify(snapshot)).digest('hex');
 }
 
@@ -23,7 +25,7 @@ export async function sendCollectorSnapshot(snapshot: object, config: { hubUrl: 
   }
 }
 
-export function createCollectorPublisher(deps: { createHash: (algorithm: string) => { update: (data: string) => { digest: (format: string) => string }; digest: (format: string) => string }; fetch: (url: string, options: { method: string; headers: Record<string, string>; body: string }) => Promise<{ ok: boolean; status: number; statusText: string }>; console: { log: (...args: unknown[]) => void; error: (...args: unknown[]) => void }; setTimeout: typeof setTimeout; clearTimeout: typeof clearTimeout }, config: { hubUrl: string; hubAuthToken: string }, buildSnapshot: () => Promise<SnapshotWithSessions>): {
+export function createCollectorPublisher(deps: { createHash: typeof crypto.createHash; fetch: (url: string, options: { method: string; headers: Record<string, string>; body: string }) => Promise<{ ok: boolean; status: number; statusText: string }>; console: { log: (...args: unknown[]) => void; error: (...args: unknown[]) => void }; setTimeout: typeof setTimeout; clearTimeout: typeof clearTimeout }, config: { hubUrl: string; hubAuthToken: string }, buildSnapshot: () => Promise<SnapshotWithSessions>): {
   publishSnapshot: () => Promise<void>;
   scheduleFlush: () => void;
   clearFlushTimer: () => void;

--- a/collector/snapshot.ts
+++ b/collector/snapshot.ts
@@ -30,7 +30,7 @@ export type CollectorSnapshotConfig = {
 
 export type CollectorSnapshotDeps = {
   getAllSessions: (activeThresholdMs: number) => Promise<SessionSummary[]>;
-  getSessionDetailByProvider: (provider: string, sessionId: string, project?: string) => Promise<SessionDetail | null>;
+  getSessionDetailByProvider: (provider: string, sessionId: string, project: string | null) => Promise<SessionDetail | null>;
   getActiveProviders: () => unknown[];
   claudeAdapter?: {
     getTeams?: () => Promise<unknown[]> | unknown[];
@@ -55,7 +55,7 @@ export async function buildCollectorSnapshot(deps: CollectorSnapshotDeps, config
 
   const activeSessions = await deps.getAllSessions(config.activeThresholdMs);
   for (const session of activeSessions) {
-    const detail = session.detail || await deps.getSessionDetailByProvider(session.provider, session.sessionId, session.project);
+    const detail = session.detail || await deps.getSessionDetailByProvider(session.provider, session.sessionId, session.project ?? null);
     const normalized = normalizeSession(session, detail);
     normalizedSessions.push(normalized);
 

--- a/hubreceiver/routes.ts
+++ b/hubreceiver/routes.ts
@@ -1,8 +1,9 @@
 import http from 'http';
-const { setCorsHeaders, sendJson, sendError, safeLimit, readBoundedBody } = require('../shared/http-utils.ts');
-const { defaultUsage } = require('./state.ts');
 
-function maybeGetAuthToken(req: http.IncomingMessage) {
+import { setCorsHeaders, sendJson, sendError, safeLimit, readBoundedBody } from '../shared/http-utils.js';
+import { defaultUsage } from './state.js';
+
+export function maybeGetAuthToken(req: http.IncomingMessage) {
   const header = req.headers.authorization || '';
   return header.replace(/^Bearer /i, '');
 }
@@ -17,7 +18,7 @@ interface HubreceiverDeps {
   maxSnapshotBytes: number;
 }
 
-function createHubreceiverRequestHandler(deps: HubreceiverDeps) {
+export function createHubreceiverRequestHandler(deps: HubreceiverDeps) {
   return (req: http.IncomingMessage, res: http.ServerResponse) => {
     if (req.method === 'OPTIONS') {
       setCorsHeaders(res);
@@ -116,8 +117,3 @@ function createHubreceiverRequestHandler(deps: HubreceiverDeps) {
     sendError(res, 404, 'Not Found');
   };
 }
-
-module.exports = {
-  maybeGetAuthToken,
-  createHubreceiverRequestHandler,
-};

--- a/hubreceiver/server.ts
+++ b/hubreceiver/server.ts
@@ -1,10 +1,11 @@
-require('../load-local-env.ts');
+import '../load-local-env.js';
 
 import http from 'http';
 import net from 'net';
-const { applySnapshot, getCurrentState, getSessionDetail, getHistory, defaultUsage } = require('./state');
-const { createHubreceiverRequestHandler } = require('./routes');
-const { createHubWebSocketManager } = require('./ws');
+
+import { applySnapshot, getCurrentState, getSessionDetail, getHistory } from './state.js';
+import { createHubreceiverRequestHandler } from './routes.js';
+import { createHubWebSocketManager } from './ws.js';
 
 const PORT = Number(process.env.HUB_PORT || 3030);
 const AUTH_TOKEN = process.env.HUB_AUTH_TOKEN || 'dev-secret';
@@ -16,7 +17,6 @@ const server = http.createServer(createHubreceiverRequestHandler({
   getCurrentState,
   getSessionDetail,
   getHistory,
-  defaultUsage,
   wsManager,
   authToken: AUTH_TOKEN,
   maxSnapshotBytes: MAX_SNAPSHOT_BYTES,

--- a/hubreceiver/state.ts
+++ b/hubreceiver/state.ts
@@ -3,7 +3,7 @@
  * CollectorSnapshot shape is compatible with shared/types.ts CollectorSnapshot.
  */
 
-function defaultUsage() {
+export function defaultUsage() {
   return {
     account: {
       subscriptionType: null,
@@ -56,13 +56,13 @@ function normalizeSnapshot(snapshot: SnapshotInput) {
   };
 }
 
-function applySnapshot(snapshot: SnapshotInput) {
+export function applySnapshot(snapshot: SnapshotInput) {
   const normalized = normalizeSnapshot(snapshot);
   collectors.set(normalized.collectorId, normalized);
   return getCurrentState();
 }
 
-function getCurrentState() {
+export function getCurrentState() {
   const sessionMap = new Map();
   const teamMap = new Map();
   const taskMap = new Map();
@@ -127,12 +127,12 @@ function getCurrentState() {
   };
 }
 
-function getSessionDetail(sessionId: string, provider: string) {
+export function getSessionDetail(sessionId: string, provider: string) {
   const key = `${provider}:${sessionId}`;
   return getCurrentState().sessionDetails.get(key) || { toolHistory: [], messages: [], tokenUsage: null, sessionId };
 }
 
-function getHistory(limit = 100) {
+export function getHistory(limit = 100) {
   const entries = [];
   for (const [key, detail] of getCurrentState().sessionDetails.entries()) {
     const [provider, sessionId] = key.split(':');
@@ -149,11 +149,3 @@ function getHistory(limit = 100) {
   entries.sort((a, b) => a.ts - b.ts);
   return entries.slice(-limit);
 }
-
-module.exports = {
-  applySnapshot,
-  getCurrentState,
-  getSessionDetail,
-  getHistory,
-  defaultUsage,
-};

--- a/hubreceiver/ws.ts
+++ b/hubreceiver/ws.ts
@@ -1,7 +1,8 @@
 import http from 'http';
 import net from 'net';
-const { computeAcceptKey } = require('../shared/ws-utils.ts');
-const { wsSend, wsBroadcast } = require('../shared/ws-helpers.js');
+
+import { computeAcceptKey } from '../shared/ws-utils.js';
+import { wsSend, wsBroadcast } from '../shared/ws-helpers.js';
 
 interface HubState {
   sessions: unknown[];
@@ -12,7 +13,7 @@ interface HubState {
   timestamp: number;
 }
 
-function createHubWebSocketManager(getCurrentState: () => HubState) {
+export function createHubWebSocketManager(getCurrentState: () => HubState) {
   const wsClients = new Set<net.Socket>();
 
   function buildWsPayload(type: string) {
@@ -68,7 +69,3 @@ function createHubWebSocketManager(getCurrentState: () => HubState) {
     handleUpgrade,
   };
 }
-
-module.exports = {
-  createHubWebSocketManager,
-};

--- a/load-local-env.ts
+++ b/load-local-env.ts
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
 
 function unquote(value: string, quote: string): string {
   if (quote === '"') {
@@ -42,7 +42,7 @@ function parseLine(line: string): { key: string; value: string } | null {
   return { key, value: rawValue };
 }
 
-function loadLocalEnv(filePath = path.join(__dirname, '.env.local')) {
+export function loadLocalEnv(filePath = path.join(process.cwd(), '.env.local')) {
   if (!fs.existsSync(filePath)) return false;
 
   const contents = fs.readFileSync(filePath, 'utf8');
@@ -59,4 +59,4 @@ function loadLocalEnv(filePath = path.join(__dirname, '.env.local')) {
 
 loadLocalEnv();
 
-module.exports = loadLocalEnv;
+export default loadLocalEnv;

--- a/runtime-config.shared.ts
+++ b/runtime-config.shared.ts
@@ -1,16 +1,16 @@
-const { DEFAULT_AGENT_NAME_POOL, DEFAULT_SESSION_NAME_POOL, toList } = require('./shared/name-pools');
+import { DEFAULT_AGENT_NAME_POOL, DEFAULT_SESSION_NAME_POOL, toList } from './shared/name-pools.js';
 
-function normalizeAgentNamePool(rawPool = '') {
+export function normalizeAgentNamePool(rawPool = '') {
   const pool = toList(rawPool);
   return pool.length > 0 ? pool : DEFAULT_AGENT_NAME_POOL;
 }
 
-function normalizeNameMode(rawMode: unknown, fallback: string = 'autodetected'): string {
+export function normalizeNameMode(rawMode: unknown, fallback: string = 'autodetected'): string {
   const mode = String(rawMode || '').trim().toLowerCase();
   return mode === 'pooled' || mode === 'autodetected' ? mode : fallback;
 }
 
-function readProviderNameModes(env = process.env) {
+export function readProviderNameModes(env = process.env) {
   const providers = {
     claude: env.CLAUDEVILLE_NAME_MODE_CLAUDE,
     codex: env.CLAUDEVILLE_NAME_MODE_CODEX,
@@ -29,7 +29,7 @@ function readProviderNameModes(env = process.env) {
   return modes;
 }
 
-function buildRuntimeConfig(env = process.env) {
+export function buildRuntimeConfig(env = process.env) {
   const hubHttpUrl = env.HUB_HTTP_URL || env.HUB_URL || 'http://localhost:4000';
   const hubWsUrl = env.HUB_WS_URL || `${hubHttpUrl.replace(/^http/, 'ws').replace(/\/$/, '')}/ws`;
 
@@ -42,12 +42,3 @@ function buildRuntimeConfig(env = process.env) {
     sessionNamePool: normalizeAgentNamePool(env.CLAUDEVILLE_SESSION_NAME_POOL),
   };
 }
-
-module.exports = {
-  DEFAULT_AGENT_NAME_POOL,
-  DEFAULT_SESSION_NAME_POOL,
-  normalizeAgentNamePool,
-  normalizeNameMode,
-  readProviderNameModes,
-  buildRuntimeConfig,
-};

--- a/shared/mime-types.js
+++ b/shared/mime-types.js
@@ -1,6 +1,6 @@
 // Shared MIME type map — superset of both servers' needs.
 
-const MIME_TYPES = {
+export const MIME_TYPES = {
   '.html': 'text/html; charset=utf-8',
   '.css': 'text/css; charset=utf-8',
   '.js': 'application/javascript; charset=utf-8',
@@ -17,5 +17,3 @@ const MIME_TYPES = {
   '.woff2': 'font/woff2',
   '.ttf': 'font/ttf',
 };
-
-module.exports = { MIME_TYPES };

--- a/shared/session-utils.js
+++ b/shared/session-utils.js
@@ -11,7 +11,7 @@
  * @param {{ input?: number, output?: number }|null} fallbackTokens
  * @returns {{ input: number, output: number }}
  */
-function normalizeTokens(tokenUsage, fallbackTokens = null) {
+export function normalizeTokens(tokenUsage, fallbackTokens = null) {
   if (tokenUsage) {
     return {
       input: Number(tokenUsage.totalInput || tokenUsage.input || 0),
@@ -27,10 +27,8 @@ function normalizeTokens(tokenUsage, fallbackTokens = null) {
  * @param {object} detailRaw
  * @returns {{ tokenUsage: object|null, tokens: { input: number, output: number } }}
  */
-function normalizeSessionTokens(session, detailRaw) {
+export function normalizeSessionTokens(session, detailRaw) {
   const tokenUsage = detailRaw?.tokenUsage || null;
   const tokens = normalizeTokens(tokenUsage, session.tokens || null);
   return { tokenUsage, tokens };
 }
-
-module.exports = { normalizeTokens, normalizeSessionTokens };

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -23,6 +23,50 @@ export interface Session {
   startedAt?: number;
 }
 
+export interface WatchPath {
+  type: 'file' | 'directory';
+  path: string;
+  filter?: string;
+  recursive?: boolean;
+}
+
+export interface AdapterSessionDetail {
+  toolHistory: Array<{ tool?: string; detail?: string; ts?: number }>;
+  messages: Array<{ role?: string; text?: string; ts?: number }>;
+  tokenUsage?: {
+    input?: number;
+    output?: number;
+    totalInput?: number;
+    totalOutput?: number;
+  } | null;
+  sessionId?: string;
+}
+
+export interface AgentSessionSummary extends Omit<Session, 'displayName'> {
+  project: string | null;
+  detail?: AdapterSessionDetail | null;
+  lastMessage?: string | null;
+  lastTool?: string | null;
+  lastToolInput?: string | null;
+  filePath?: string | null;
+  agentId?: string | null;
+  agentType?: string | null;
+  displayName?: string | null;
+  parentSessionId?: string | null;
+}
+
+export interface AgentAdapter {
+  name: string;
+  provider: string;
+  homeDir: string;
+  isAvailable(): boolean;
+  getActiveSessions(activeThresholdMs: number): Promise<AgentSessionSummary[]>;
+  getSessionDetail(sessionId: string, project: string | null, filePath?: string | null): Promise<AdapterSessionDetail>;
+  getWatchPaths(): WatchPath[];
+  getTeams?(): Promise<unknown[]> | unknown[];
+  getTasks?(): Promise<unknown[]> | unknown[];
+}
+
 /** A snapshot published by one collector instance. */
 export interface CollectorSnapshot {
   collectorId: string;

--- a/shared/watch-utils.js
+++ b/shared/watch-utils.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+import fs from 'fs';
 
 /**
  * Watch an array of watch-path objects and call onChange whenever any of them change.
@@ -10,7 +10,7 @@ const fs = require('fs');
  * @param {number} [debounceMs=200]  - Debounce delay
  * @returns {{ watchCount: number }}
  */
-function createFileWatchers(watchPaths, onChange, debounceMs = 200) {
+export function createFileWatchers(watchPaths, onChange, debounceMs = 200) {
   let watchCount = 0;
   let timer = null;
 
@@ -41,5 +41,3 @@ function createFileWatchers(watchPaths, onChange, debounceMs = 200) {
 
   return { watchCount };
 }
-
-module.exports = { createFileWatchers };

--- a/shared/ws-helpers.js
+++ b/shared/ws-helpers.js
@@ -8,9 +8,9 @@
  * The frame-building utilities (createWebSocketFrame, computeAcceptKey)
  * live in shared/ws-utils.js — this file only handles send/broadcast.
  */
-const { createWebSocketFrame } = require('./ws-utils.ts');
+import { createWebSocketFrame } from './ws-utils.js';
 
-const DISCONNECTED_CODES = new Set(['EPIPE', 'ECONNRESET', 'EBADF', 'ENOTCONN']);
+export const DISCONNECTED_CODES = new Set(['EPIPE', 'ECONNRESET', 'EBADF', 'ENOTCONN']);
 
 /**
  * Send a JSON payload over a WebSocket socket.
@@ -20,7 +20,7 @@ const DISCONNECTED_CODES = new Set(['EPIPE', 'ECONNRESET', 'EBADF', 'ENOTCONN'])
  * @param {object} data
  * @param {Set} clientSet - the Set tracking all active clients (for cleanup)
  */
-function wsSend(socket, data, clientSet = null) {
+export function wsSend(socket, data, clientSet = null) {
   try {
     if (socket.destroyed || !socket.writable) {
       if (clientSet) clientSet.delete(socket);
@@ -50,7 +50,7 @@ function wsSend(socket, data, clientSet = null) {
  * @param {object} data
  * @param {Set<import('net').Socket>} wsClients
  */
-function wsBroadcast(data, wsClients) {
+export function wsBroadcast(data, wsClients) {
   let frame;
   try {
     frame = createWebSocketFrame(JSON.stringify(data));
@@ -80,5 +80,3 @@ function wsBroadcast(data, wsClients) {
     wsClients.delete(socket);
   }
 }
-
-module.exports = { wsSend, wsBroadcast, DISCONNECTED_CODES };

--- a/shared/ws-utils.ts
+++ b/shared/ws-utils.ts
@@ -5,9 +5,9 @@
  * ping/pong + frame-issue tracking is preserved.
  */
 
-const crypto = require('crypto');
+import crypto from 'crypto';
 
-const WS_MAGIC_STRING = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+export const WS_MAGIC_STRING = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 
 /**
  * Build a WebSocket frame for the given data.
@@ -15,7 +15,7 @@ const WS_MAGIC_STRING = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
  * @param {number} opcode - 0x1 = text, 0x8 = close, 0x9 = ping, 0xA = pong
  * @returns {Buffer}
  */
-function createWebSocketFrame(data: string | Buffer, opcode: number = 0x1) {
+export function createWebSocketFrame(data: string | Buffer, opcode: number = 0x1) {
   const payload = Buffer.isBuffer(data) ? data : Buffer.from(String(data), 'utf-8');
   const length = payload.length;
 
@@ -40,10 +40,8 @@ function createWebSocketFrame(data: string | Buffer, opcode: number = 0x1) {
 }
 
 /** Compute the Sec-WebSocket-Accept key for an upgrade response. */
-function computeAcceptKey(websocketKey: string) {
+export function computeAcceptKey(websocketKey: string) {
   return crypto.createHash('sha1')
     .update(websocketKey + WS_MAGIC_STRING)
     .digest('base64');
 }
-
-module.exports = { createWebSocketFrame, computeAcceptKey, WS_MAGIC_STRING };


### PR DESCRIPTION
Closes #47 and #49.

- Adds a shared AgentAdapter contract and types the registry against it.
- Converts backend/shared modules to ESM imports/exports.
- Keeps the adapter/collector/hubreceiver/test surface green.