### PR TITLE
[codex] address review nits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,12 +9,7 @@ coverage
 .env.local
 
 
-# tsgo emitted files
-claudeville/**/*.js
-!claudeville/widget/**/*.js
-frontend/**/*.js
-hubreceiver/**/*.js
-collector/**/*.js
+# Project-local generated JavaScript
 load-local-env.js
 demo-server.js
 runtime-config.shared.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,5 @@
 Primary repository guidance lives in [`.github/copilot-instructions.md`](./.github/copilot-instructions.md).
 
 When working in this repository, follow that file first. For the legacy app subtree, also check `claudeville/CLAUDE.md`, which points back here.
+
+For issue, branch, and pull request workflows, keep the work and the PR on the fork unless the user explicitly asks to target upstream.

--- a/claudeville/adapters/claude.test.ts
+++ b/claudeville/adapters/claude.test.ts
@@ -116,7 +116,7 @@ describe('claude adapter', () => {
         } catch { return []; }
       };
       const result = readLastLines(emptyFile);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       // Empty file: ''.trim() → '', ''.split('\n') → ['']
       expect(result).toEqual(['']);
     });
@@ -136,7 +136,7 @@ describe('claude adapter', () => {
         } catch { return []; }
       };
       const result = readLastLines(file, 3);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toEqual(['line3', 'line4', 'line5']);
     });
 
@@ -155,7 +155,7 @@ describe('claude adapter', () => {
         } catch { return []; }
       };
       const result = readLastLines(file, 100);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toEqual(['a', 'b']);
     });
 
@@ -174,7 +174,7 @@ describe('claude adapter', () => {
         } catch { return []; }
       };
       const result = readLastLines(file, 5);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toEqual(['only one line']);
     });
   });
@@ -271,7 +271,7 @@ describe('claude adapter', () => {
         return tools.slice(-maxItems);
       };
       const result = getToolHistory(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(1);
       expect(result[0].tool).toBe('Read');
       expect(result[0].detail).toBe('/tmp/test.js');
@@ -315,7 +315,7 @@ describe('claude adapter', () => {
         return tools.slice(-maxItems);
       };
       const result = getToolHistory(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(0);
     });
 
@@ -364,7 +364,7 @@ describe('claude adapter', () => {
         return tools.slice(-maxItems);
       };
       const result = getToolHistory(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(6);
       expect(result[0].detail).toBe('npm run build');
       expect(result[1].detail).toBe('TODO');
@@ -412,7 +412,7 @@ describe('claude adapter', () => {
         return tools.slice(-maxItems);
       };
       const result = getToolHistory(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result[0].detail.length).toBe(80);
     });
 
@@ -453,7 +453,7 @@ describe('claude adapter', () => {
         return tools.slice(-maxItems);
       };
       const result = getToolHistory(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result[0].tool).toBe('unknown');
     });
 
@@ -496,7 +496,7 @@ describe('claude adapter', () => {
         return tools.slice(-maxItems);
       };
       const result = getToolHistory(file, 5);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(5);
     });
   });
@@ -531,7 +531,7 @@ describe('claude adapter', () => {
         return messages.slice(-maxItems);
       };
       const result = getRecentMessages(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(1);
       expect(result[0].text).toBe('Hello world');
       expect(result[0].role).toBe('assistant');
@@ -566,7 +566,7 @@ describe('claude adapter', () => {
         return messages.slice(-maxItems);
       };
       const result = getRecentMessages(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(1);
       expect(result[0].text).toBe('visible');
     });
@@ -600,7 +600,7 @@ describe('claude adapter', () => {
         return messages.slice(-maxItems);
       };
       const result = getRecentMessages(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(0);
     });
 
@@ -633,7 +633,7 @@ describe('claude adapter', () => {
         return messages.slice(-maxItems);
       };
       const result = getRecentMessages(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result[0].text.length).toBe(200);
     });
 
@@ -668,7 +668,7 @@ describe('claude adapter', () => {
         return messages.slice(-maxItems);
       };
       const result = getRecentMessages(file, 3);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(3);
     });
   });
@@ -710,7 +710,7 @@ describe('claude adapter', () => {
         return usage;
       };
       const result = getTokenUsage(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.totalInput).toBe(250);
       expect(result.totalOutput).toBe(450);
       expect(result.cacheRead).toBe(110);
@@ -752,7 +752,7 @@ describe('claude adapter', () => {
         return usage;
       };
       const result = getTokenUsage(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.totalInput).toBe(0);
       expect(result.totalOutput).toBe(0);
       expect(result.turnCount).toBe(1);
@@ -792,7 +792,7 @@ describe('claude adapter', () => {
         return usage;
       };
       const result = getTokenUsage(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.turnCount).toBe(0);
       expect(result.contextWindow).toBe(0);
     });
@@ -862,7 +862,7 @@ describe('claude adapter', () => {
         return detail;
       };
       const result = getSessionDetail('session-abc', projPath);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.model).toBe('claude-sonnet-4-5');
       expect(result.lastTool).toBe('Read');
       expect(result.lastToolInput).toBe('readme.txt');
@@ -920,7 +920,7 @@ describe('claude adapter', () => {
         return detail;
       };
       const result = getSessionDetail('s', projPath);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.lastMessage).not.toBeNull();
       expect(result.lastMessage!.length).toBe(80);
     });
@@ -976,7 +976,7 @@ describe('claude adapter', () => {
         return detail;
       };
       const result = getSessionDetail('s', projPath);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.lastTool).toBe('Bash');
       expect(result.lastToolInput).not.toBeNull();
       expect(result.lastToolInput!.length).toBe(60); // truncated at 60
@@ -1021,7 +1021,7 @@ describe('claude adapter', () => {
         return fs.existsSync(sessionFile) ? sessionFile : null;
       };
       const result = resolveSessionFilePath('nonexistent', projPath);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toBeNull();
     });
 
@@ -1054,7 +1054,7 @@ describe('claude adapter', () => {
         return fs.existsSync(sessionFile) ? sessionFile : null;
       };
       const result = resolveSessionFilePath('my-session', projPath);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).not.toBeNull();
       expect(result!).toContain('my-session.jsonl');
     });
@@ -1088,7 +1088,7 @@ describe('claude adapter', () => {
         return fs.existsSync(sessionFile) ? sessionFile : null;
       };
       const result = resolveSessionFilePath('subagent-abc123', projPath);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).not.toBeNull();
       expect(result!).toContain('agent-abc123.jsonl');
     });
@@ -1124,7 +1124,7 @@ describe('claude adapter', () => {
         return 0;
       };
       const result = getSessionFileActivity('active-session', projPath);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toBeGreaterThan(0);
     });
 
@@ -1155,7 +1155,7 @@ describe('claude adapter', () => {
         return 0;
       };
       const result = getSessionFileActivity('missing', projPath);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toBe(0);
     });
   });

--- a/claudeville/adapters/codex.test.ts
+++ b/claudeville/adapters/codex.test.ts
@@ -33,7 +33,7 @@ describe('codex adapter', () => {
         } catch { return []; }
       };
       const result = await readLines(file, { from: 'end', count: 3 });
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toEqual(['line3', 'line4', 'line5']);
     });
 
@@ -51,7 +51,7 @@ describe('codex adapter', () => {
         } catch { return []; }
       };
       const result = await readLines(file, { from: 'start', count: 2 });
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toEqual(['line1', 'line2']);
     });
   });
@@ -124,7 +124,7 @@ describe('codex adapter', () => {
         return detail;
       };
       const result = await parseRollout(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.model).toBe('gpt-4');
       expect(result.project).toBe('/project/codex');
     });
@@ -162,7 +162,7 @@ describe('codex adapter', () => {
         return detail;
       };
       const result = await parseRollout(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.lastTool).toBe('shell');
       expect(result.lastToolInput).toBe('ls -la');
     });
@@ -200,7 +200,7 @@ describe('codex adapter', () => {
         return detail;
       };
       const result = await parseRollout(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.lastTool).toBe('Bash');
       expect(result.lastToolInput).toBe('npm test');
     });
@@ -238,7 +238,7 @@ describe('codex adapter', () => {
         return detail;
       };
       const result = await parseRollout(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.lastMessage).toBe('Here is the result');
     });
 
@@ -276,7 +276,7 @@ describe('codex adapter', () => {
         return detail;
       };
       const result = await parseRollout(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.lastToolInput!.length).toBe(60);
     });
   });
@@ -291,7 +291,7 @@ describe('codex adapter', () => {
       const parseJsonLines = (lines) => { const r = []; for (const l of lines) { if (!l.trim()) continue; try { r.push(JSON.parse(l)); } catch { /* ignore */ } } return r; };
       const getToolHistory = async (fp, maxItems = 15) => { const tools = []; try { const lines = await readLines(fp, { from: 'end', count: 100 }); const entries = parseJsonLines(lines); for (const entry of entries) { if (entry.type !== 'response_item' || !entry.payload) continue; const p = entry.payload; if (p.type === 'function_call' || p.type === 'command_execution') { let d = ''; if (p.arguments) d = (typeof p.arguments === 'string' ? p.arguments : JSON.stringify(p.arguments)).substring(0, 80); else if (p.command) d = p.command.substring(0, 80); tools.push({ tool: p.name || p.type, detail: d, ts: entry.timestamp ? new Date(entry.timestamp).getTime() : 0 }); } } } catch { /* ignore */ } return tools.slice(-maxItems); };
       const result = await getToolHistory(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(1);
       expect(result[0].tool).toBe('Bash');
       expect(result[0].ts).toBeGreaterThan(0);
@@ -307,7 +307,7 @@ describe('codex adapter', () => {
       const parseJsonLines = (lines) => { const r = []; for (const l of lines) { if (!l.trim()) continue; try { r.push(JSON.parse(l)); } catch { /* ignore */ } } return r; };
       const getToolHistory = async (fp, maxItems = 15) => { const tools = []; try { const lines = await readLines(fp, { from: 'end', count: 100 }); const entries = parseJsonLines(lines); for (const entry of entries) { if (entry.type !== 'response_item' || !entry.payload) continue; const p = entry.payload; if (p.type === 'function_call' || p.type === 'command_execution') { let d = ''; if (p.arguments) d = (typeof p.arguments === 'string' ? p.arguments : JSON.stringify(p.arguments)).substring(0, 80); else if (p.command) d = p.command.substring(0, 80); tools.push({ tool: p.name || p.type, detail: d, ts: entry.timestamp ? new Date(entry.timestamp).getTime() : 0 }); } } } catch { /* ignore */ } return tools.slice(-maxItems); };
       const result = await getToolHistory(file, 5);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(5);
     });
   });
@@ -322,7 +322,7 @@ describe('codex adapter', () => {
       const parseJsonLines = (lines) => { const r = []; for (const l of lines) { if (!l.trim()) continue; try { r.push(JSON.parse(l)); } catch { /* ignore */ } } return r; };
       const getRecentMessages = async (fp, maxItems = 5) => { const messages = []; try { const lines = await readLines(fp, { from: 'end', count: 60 }); const entries = parseJsonLines(lines); for (const entry of entries) { if (entry.type !== 'response_item' || !entry.payload) continue; const p = entry.payload; if (p.type !== 'message') continue; const role = p.role || 'assistant'; let text = ''; if (typeof p.content === 'string') text = p.content; else if (Array.isArray(p.content)) { for (const block of p.content) { if ((block.type === 'output_text' || block.type === 'text') && block.text) { text = block.text; break; } if (block.type === 'input_text' && block.text && !block.text.startsWith('<environment_context>')) { text = block.text; break; } } } if (text.trim().length > 0) messages.push({ role, text: text.trim().substring(0, 200), ts: entry.timestamp ? new Date(entry.timestamp).getTime() : 0 }); } } catch { /* ignore */ } return messages.slice(-maxItems); };
       const result = await getRecentMessages(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(1);
       expect(result[0].text).toBe('Command output');
       expect(result[0].role).toBe('assistant');
@@ -336,7 +336,7 @@ describe('codex adapter', () => {
       const parseJsonLines = (lines) => { const r = []; for (const l of lines) { if (!l.trim()) continue; try { r.push(JSON.parse(l)); } catch { /* ignore */ } } return r; };
       const getRecentMessages = async (fp, maxItems = 5) => { const messages = []; try { const lines = await readLines(fp, { from: 'end', count: 60 }); const entries = parseJsonLines(lines); for (const entry of entries) { if (entry.type !== 'response_item' || !entry.payload) continue; const p = entry.payload; if (p.type !== 'message') continue; const role = p.role || 'assistant'; let text = ''; if (typeof p.content === 'string') text = p.content; else if (Array.isArray(p.content)) { for (const block of p.content) { if ((block.type === 'output_text' || block.type === 'text') && block.text) { text = block.text; break; } if (block.type === 'input_text' && block.text && !block.text.startsWith('<environment_context>')) { text = block.text; break; } } } if (text.trim().length > 0) messages.push({ role, text: text.trim().substring(0, 200), ts: entry.timestamp ? new Date(entry.timestamp).getTime() : 0 }); } } catch { /* ignore */ } return messages.slice(-maxItems); };
       const result = await getRecentMessages(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(1);
       expect(result[0].text).toBe('visible');
     });
@@ -351,7 +351,7 @@ describe('codex adapter', () => {
       const parseJsonLines = (lines) => { const r = []; for (const l of lines) { if (!l.trim()) continue; try { r.push(JSON.parse(l)); } catch { /* ignore */ } } return r; };
       const getRecentMessages = async (fp, maxItems = 5) => { const messages = []; try { const lines = await readLines(fp, { from: 'end', count: 60 }); const entries = parseJsonLines(lines); for (const entry of entries) { if (entry.type !== 'response_item' || !entry.payload) continue; const p = entry.payload; if (p.type !== 'message') continue; const role = p.role || 'assistant'; let text = ''; if (typeof p.content === 'string') text = p.content; else if (Array.isArray(p.content)) { for (const block of p.content) { if ((block.type === 'output_text' || block.type === 'text') && block.text) { text = block.text; break; } if (block.type === 'input_text' && block.text && !block.text.startsWith('<environment_context>')) { text = block.text; break; } } } if (text.trim().length > 0) messages.push({ role, text: text.trim().substring(0, 200), ts: entry.timestamp ? new Date(entry.timestamp).getTime() : 0 }); } } catch { /* ignore */ } return messages.slice(-maxItems); };
       const result = await getRecentMessages(file, 3);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(3);
     });
   });
@@ -400,7 +400,7 @@ describe('codex adapter', () => {
         return results;
       };
       const result = await scanRecentRollouts(path.join(tmp, 'sessions'), 120000);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toEqual([]);
     });
 
@@ -449,7 +449,7 @@ describe('codex adapter', () => {
         return results;
       };
       const result = await scanRecentRollouts(path.join(tmp, 'sessions'), 120000);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(1);
       expect(result[0].fileName).toBe('rollout-2025-01-22T10-30-00-abc123.jsonl');
       expect(result[0].mtime).toBeGreaterThan(0);

--- a/claudeville/adapters/copilot.test.ts
+++ b/claudeville/adapters/copilot.test.ts
@@ -37,7 +37,7 @@ describe('copilot adapter', () => {
         } catch { return []; }
       };
       const result = await readLines(file, { from: 'end', count: 3 });
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toEqual(['line3', 'line4', 'line5']);
     });
 
@@ -58,7 +58,7 @@ describe('copilot adapter', () => {
         } catch { return []; }
       };
       const result = await readLines(file, { from: 'start', count: 2 });
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toEqual(['line1', 'line2']);
     });
 
@@ -79,7 +79,7 @@ describe('copilot adapter', () => {
         } catch { return []; }
       };
       const result = await readLines(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toEqual(['']);
     });
   });
@@ -267,7 +267,7 @@ describe('copilot adapter', () => {
         return detail;
       };
       const result = await parseSession(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.model).toBe('gpt-4o');
       expect(result.project).toBe('/project/my-app');
     });
@@ -311,7 +311,7 @@ describe('copilot adapter', () => {
         return detail;
       };
       const result = await parseSession(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.lastTool).toBe('Bash');
       expect(result.lastToolInput).toBe('ls -la');
     });
@@ -355,7 +355,7 @@ describe('copilot adapter', () => {
         return detail;
       };
       const result = await parseSession(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.lastTool).toBe('Read');
       expect(result.lastToolInput).toBe('/tmp/file.txt');
     });
@@ -399,7 +399,7 @@ describe('copilot adapter', () => {
         return detail;
       };
       const result = await parseSession(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.lastTool).toBe('Bash');
       expect(result.lastToolInput).toBe('{"command":"echo hi"}');
     });
@@ -421,7 +421,7 @@ describe('copilot adapter', () => {
       const parseJsonLines = (lines) => { const r = []; for (const l of lines) { if (!l.trim()) continue; try { r.push(JSON.parse(l)); } catch { /* ignore */ } } return r; };
       const getToolHistory = async (fp, maxItems = 15) => { const tools = []; try { const lines = await readLines(fp, { from: 'end', count: 100 }); const entries = parseJsonLines(lines); for (const entry of entries) { let tn = null, ti = null, ts = 0; if (entry.type === 'assistant.message' && entry.data) { const msg = entry.data; if (msg.toolCalls && Array.isArray(msg.toolCalls)) { for (const tc of msg.toolCalls) { tn = tc.name || 'tool_call'; ti = tc.input ? (typeof tc.input === 'string' ? tc.input : JSON.stringify(tc.input)).substring(0, 80) : ''; ts = entry.timestamp ? new Date(entry.timestamp).getTime() : 0; break; } } } if (!tn && entry.type === 'tool_call' && entry.data) { tn = entry.data.name || 'tool_call'; ti = entry.data.input ? (typeof entry.data.input === 'string' ? entry.data.input : JSON.stringify(entry.data.input)).substring(0, 80) : ''; ts = entry.timestamp ? new Date(entry.timestamp).getTime() : 0; } if (tn) tools.push({ tool: tn, detail: ti || '', ts }); } } catch { /* ignore */ } return tools.slice(-maxItems); };
       const result = await getToolHistory(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(1);
       expect(result[0].tool).toBe('Bash');
       expect(result[0].detail).toBe('ls');
@@ -441,7 +441,7 @@ describe('copilot adapter', () => {
       const parseJsonLines = (lines) => { const r = []; for (const l of lines) { if (!l.trim()) continue; try { r.push(JSON.parse(l)); } catch { /* ignore */ } } return r; };
       const getToolHistory = async (fp, maxItems = 15) => { const tools = []; try { const lines = await readLines(fp, { from: 'end', count: 100 }); const entries = parseJsonLines(lines); for (const entry of entries) { let tn = null, ti = null, ts = 0; if (entry.type === 'assistant.message' && entry.data) { const msg = entry.data; if (msg.toolCalls && Array.isArray(msg.toolCalls)) { for (const tc of msg.toolCalls) { tn = tc.name || 'tool_call'; ti = tc.input ? (typeof tc.input === 'string' ? tc.input : JSON.stringify(tc.input)).substring(0, 80) : ''; ts = entry.timestamp ? new Date(entry.timestamp).getTime() : 0; break; } } } if (!tn && entry.type === 'tool_call' && entry.data) { tn = entry.data.name || 'tool_call'; ti = entry.data.input ? (typeof entry.data.input === 'string' ? entry.data.input : JSON.stringify(entry.data.input)).substring(0, 80) : ''; ts = entry.timestamp ? new Date(entry.timestamp).getTime() : 0; } if (tn) tools.push({ tool: tn, detail: ti || '', ts }); } } catch { /* ignore */ } return tools.slice(-maxItems); };
       const result = await getToolHistory(file, 5);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(5);
     });
   });
@@ -463,7 +463,7 @@ describe('copilot adapter', () => {
       const extractText = (content) => { if (typeof content === 'string') return content.trim(); if (!Array.isArray(content)) return ''; for (const block of content) { if ((block.type === 'text' || block.type === 'output_text') && block.text) return block.text.trim(); } return ''; };
       const getRecentMessages = async (fp, maxItems = 5) => { const messages = []; try { const lines = await readLines(fp, { from: 'end', count: 60 }); const entries = parseJsonLines(lines); for (const entry of entries) { if (entry.type !== 'user.message' && entry.type !== 'assistant.message') continue; if (!entry.data || !entry.data.content) continue; const text = extractText(entry.data.content); if (!text) continue; messages.push({ role: entry.type === 'user.message' ? 'user' : 'assistant', text: text.substring(0, 200), ts: entry.timestamp ? new Date(entry.timestamp).getTime() : 0 }); } } catch { /* ignore */ } return messages.slice(-maxItems); };
       const result = await getRecentMessages(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(2);
       expect(result[0].role).toBe('user');
       expect(result[0].text).toBe('Hello');
@@ -487,7 +487,7 @@ describe('copilot adapter', () => {
       const extractText = (content) => { if (typeof content === 'string') return content.trim(); if (!Array.isArray(content)) return ''; for (const block of content) { if ((block.type === 'text' || block.type === 'output_text') && block.text) return block.text.trim(); } return ''; };
       const getRecentMessages = async (fp, maxItems = 5) => { const messages = []; try { const lines = await readLines(fp, { from: 'end', count: 60 }); const entries = parseJsonLines(lines); for (const entry of entries) { if (entry.type !== 'user.message' && entry.type !== 'assistant.message') continue; if (!entry.data || !entry.data.content) continue; const text = extractText(entry.data.content); if (!text) continue; messages.push({ role: entry.type === 'user.message' ? 'user' : 'assistant', text: text.substring(0, 200), ts: entry.timestamp ? new Date(entry.timestamp).getTime() : 0 }); } } catch { /* ignore */ } return messages.slice(-maxItems); };
       const result = await getRecentMessages(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(1);
       expect(result[0].text).toBe('visible');
     });
@@ -506,7 +506,7 @@ describe('copilot adapter', () => {
       const extractText = (content) => { if (typeof content === 'string') return content.trim(); if (!Array.isArray(content)) return ''; for (const block of content) { if ((block.type === 'text' || block.type === 'output_text') && block.text) return block.text.trim(); } return ''; };
       const getRecentMessages = async (fp, maxItems = 5) => { const messages = []; try { const lines = await readLines(fp, { from: 'end', count: 60 }); const entries = parseJsonLines(lines); for (const entry of entries) { if (entry.type !== 'user.message' && entry.type !== 'assistant.message') continue; if (!entry.data || !entry.data.content) continue; const text = extractText(entry.data.content); if (!text) continue; messages.push({ role: entry.type === 'user.message' ? 'user' : 'assistant', text: text.substring(0, 200), ts: entry.timestamp ? new Date(entry.timestamp).getTime() : 0 }); } } catch { /* ignore */ } return messages.slice(-maxItems); };
       const result = await getRecentMessages(file, 3);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(3);
     });
   });
@@ -539,7 +539,7 @@ describe('copilot adapter', () => {
         return results;
       };
       const result = await scanAllSessions(path.join(tmp, 'session-state'), 120000);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toEqual([]);
     });
 
@@ -571,7 +571,7 @@ describe('copilot adapter', () => {
         return results;
       };
       const result = await scanAllSessions(path.join(tmp, 'session-state'), 120000);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(1);
       expect(result[0].sessionId).toBe('abc-123-def');
       expect(result[0].filePath).toContain('events.jsonl');
@@ -683,7 +683,7 @@ describe('copilot adapter', () => {
       );
       const adapter = new CopilotAdapter();
       const detail = await adapter.getSessionDetail('copilot-test-session', '/test', path.join(sessionDir, 'events.jsonl'));
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(detail).toHaveProperty('toolHistory');
       expect(detail).toHaveProperty('messages');
       expect(detail).toHaveProperty('sessionId');

--- a/claudeville/adapters/gemini.test.ts
+++ b/claudeville/adapters/gemini.test.ts
@@ -39,7 +39,7 @@ describe('gemini adapter', () => {
       fs.writeFileSync(file, JSON.stringify({ sessionId: 'abc', messages: [] }));
       const readJsonFile = async (fp) => { try { const c = await fs.promises.readFile(fp, 'utf-8'); return JSON.parse(c); } catch { return null; } };
       const result = await readJsonFile(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toEqual({ sessionId: 'abc', messages: [] });
     });
 
@@ -49,7 +49,7 @@ describe('gemini adapter', () => {
       fs.writeFileSync(file, 'not valid json');
       const readJsonFile = async (fp) => { try { const c = await fs.promises.readFile(fp, 'utf-8'); return JSON.parse(c); } catch { return null; } };
       const result = await readJsonFile(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toBeNull();
     });
   });
@@ -82,7 +82,7 @@ describe('gemini adapter', () => {
         return detail;
       };
       const result = await parseSession(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.model).toBe('gemini-2.5-flash');
     });
 
@@ -112,7 +112,7 @@ describe('gemini adapter', () => {
         return detail;
       };
       const result = await parseSession(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.lastMessage).toBe('Hi there!');
     });
 
@@ -142,7 +142,7 @@ describe('gemini adapter', () => {
         return detail;
       };
       const result = await parseSession(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.lastTool).toBe('Bash');
       expect(result.lastToolInput).toBe('ls -la');
     });
@@ -173,7 +173,7 @@ describe('gemini adapter', () => {
         return detail;
       };
       const result = await parseSession(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.lastTool).toBe('Read');
     });
   });
@@ -202,7 +202,7 @@ describe('gemini adapter', () => {
         return tools.slice(-maxItems);
       };
       const result = await getToolHistory(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(1);
       expect(result[0].tool).toBe('Bash');
       expect(result[0].ts).toBeGreaterThan(0);
@@ -234,7 +234,7 @@ describe('gemini adapter', () => {
         return tools.slice(-maxItems);
       };
       const result = await getToolHistory(file, 5);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(5);
     });
   });
@@ -266,7 +266,7 @@ describe('gemini adapter', () => {
         return msgList.slice(-maxItems);
       };
       const result = await getRecentMessages(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(2);
       expect(result[0].role).toBe('user');
       expect(result[0].text).toBe('Hello');
@@ -299,7 +299,7 @@ describe('gemini adapter', () => {
         return msgList.slice(-maxItems);
       };
       const result = await getRecentMessages(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(1);
       expect(result[0].text).toBe('Visible');
     });
@@ -330,7 +330,7 @@ describe('gemini adapter', () => {
         return msgList.slice(-maxItems);
       };
       const result = await getRecentMessages(file, 3);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(3);
     });
   });
@@ -367,7 +367,7 @@ describe('gemini adapter', () => {
         return results;
       };
       const result = await scanActiveSessions(path.join(tmp, 'tmp'), 120000);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toEqual([]);
     });
 
@@ -404,7 +404,7 @@ describe('gemini adapter', () => {
         return results;
       };
       const result = await scanActiveSessions(path.join(tmp, 'tmp'), 120000);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(1);
       expect(result[0].fileName).toBe('session-abc123.json');
       expect(result[0].projectHash).toBe('abc123hash');

--- a/claudeville/adapters/jsonl-utils.ts
+++ b/claudeville/adapters/jsonl-utils.ts
@@ -5,11 +5,13 @@
  */
 import fs from 'fs';
 
-/**
- * @typedef {{ from?: 'start' | 'end'; count?: number; scope?: string }} ReadLinesOptions
- */
+type ReadLinesOptions = {
+  from?: 'start' | 'end';
+  count?: number;
+  scope?: string;
+};
 
-export function debugAdapterError(scope, operation, err, context = '') {
+export function debugAdapterError(scope: string, operation: string, err: unknown, context = '') {
   if (!process.env.DEBUG) return;
 
   const message = err instanceof Error ? err.message : String(err);
@@ -19,11 +21,8 @@ export function debugAdapterError(scope, operation, err, context = '') {
 
 /**
  * Read the last N (or first N) lines of a file as strings.
- * @param {string} filePath
- * @param {ReadLinesOptions} options
- * @returns {Promise<string[]>}
  */
-export async function readLines(filePath, { from = 'end', count = 50, scope = 'jsonl-utils' } = {}) {
+export async function readLines(filePath: string, { from = 'end', count = 50, scope = 'jsonl-utils' }: ReadLinesOptions = {}) {
   try {
     if (!fs.existsSync(filePath)) return [];
     const content = await fs.promises.readFile(filePath, 'utf-8');
@@ -38,11 +37,9 @@ export async function readLines(filePath, { from = 'end', count = 50, scope = 'j
 
 /**
  * Parse an array of JSONL strings into objects, skipping bad lines.
- * @param {string[]} lines
- * @returns {any[]}
  */
-export function parseJsonLines(lines, scope = 'jsonl-utils') {
-  const results = [];
+export function parseJsonLines(lines: string[], scope = 'jsonl-utils') {
+  const results: any[] = [];
   for (const line of lines) {
     if (!line.trim()) continue;
     try { results.push(JSON.parse(line)); } catch (err) {

--- a/claudeville/adapters/openclaw.test.ts
+++ b/claudeville/adapters/openclaw.test.ts
@@ -18,7 +18,7 @@ describe('openclaw adapter', () => {
       fs.writeFileSync(file, 'a\nb\nc\nd\ne\n');
       const readLines = async (fp, opts = {}) => { try { if (!fs.existsSync(fp)) return []; const c = await fs.promises.readFile(fp, 'utf-8'); const l = c.trim().split('\n'); return opts.from === 'start' ? l.slice(0, opts.count || 50) : l.slice(-(opts.count || 50)); } catch { return []; } };
       const result = await readLines(file, { from: 'end', count: 3 });
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toEqual(['c', 'd', 'e']);
     });
 
@@ -28,7 +28,7 @@ describe('openclaw adapter', () => {
       fs.writeFileSync(file, 'a\nb\nc\nd\ne\n');
       const readLines = async (fp, opts = {}) => { try { if (!fs.existsSync(fp)) return []; const c = await fs.promises.readFile(fp, 'utf-8'); const l = c.trim().split('\n'); return opts.from === 'start' ? l.slice(0, opts.count || 50) : l.slice(-(opts.count || 50)); } catch { return []; } };
       const result = await readLines(file, { from: 'start', count: 2 });
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toEqual(['a', 'b']);
     });
   });
@@ -164,7 +164,7 @@ describe('openclaw adapter', () => {
         return detail;
       };
       const result = await parseSession(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.model).toBe('gpt-4o');
     });
 
@@ -195,7 +195,7 @@ describe('openclaw adapter', () => {
         return detail;
       };
       const result = await parseSession(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.lastTool).toBe('Bash');
       expect(result.lastToolInput).toBe('ls');
     });
@@ -227,7 +227,7 @@ describe('openclaw adapter', () => {
         return detail;
       };
       const result = await parseSession(file);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result.project).toBe('/project/myapp');
     });
   });
@@ -264,7 +264,7 @@ describe('openclaw adapter', () => {
         return results;
       };
       const result = await scanAllSessionFiles(path.join(tmp, 'agents'), 120000);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toEqual([]);
     });
 
@@ -301,7 +301,7 @@ describe('openclaw adapter', () => {
         return results;
       };
       const result = await scanAllSessionFiles(path.join(tmp, 'agents'), 120000);
-      fs.rmdirSync(tmp, { recursive: true });
+      fs.rmSync(tmp, { recursive: true, force: true });
       expect(result).toHaveLength(1);
       expect(result[0].agentId).toBe('my-agent');
       expect(result[0].fileName).toBe('session-abc.jsonl');

--- a/claudeville/src/config/toolFormatting.test.ts
+++ b/claudeville/src/config/toolFormatting.test.ts
@@ -14,6 +14,10 @@ describe('toolFormatting', () => {
         expect(parseToolDetail('Task', { description: 'Ship feature' })).toBe('Ship feature');
     });
 
+    it('falls back from structured wrappers to JSON-string content', () => {
+        expect(parseToolDetail('run_in_terminal', { raw: '{"command":"npm test","goal":"Run tests"}' })).toBe('npm test');
+    });
+
     it('falls back to cleaned text and truncates bubble snippets', () => {
         expect(parseToolDetail('UnknownTool', '{ "foo": "bar" }')).toBe('foo bar');
         expect(normalizeBubbleSnippet('abcdefghijklmnopqrstuvwxyz', 10)).toBe('abcdefghij');

--- a/claudeville/src/config/toolFormatting.ts
+++ b/claudeville/src/config/toolFormatting.ts
@@ -149,18 +149,10 @@ export function extractObjectDetail(obj: Record<string, unknown>, keys: string[]
     return null;
 }
 
-export function parseToolDetail(toolName: string, rawInput: unknown) {
-    if (rawInput && typeof rawInput === 'object') {
-        const genericMatch = extractValueFromUnknown(rawInput);
-        if (genericMatch) {
-            return genericMatch;
-        }
-    }
-
-    const text = normalizeInlineText(rawInput);
+function parseToolDetailText(textInput: unknown, keys: string[]) {
+    const text = normalizeInlineText(textInput);
     if (!text) return null;
 
-    const keys = [...(TOOL_DETAIL_KEYS[toolName] || []), ...DEFAULT_DETAIL_KEYS];
     const regexMatch = extractRegexField(text, keys);
     if (regexMatch) {
         return regexMatch;
@@ -188,6 +180,34 @@ export function parseToolDetail(toolName: string, rawInput: unknown) {
             .replace(/[{}[\]"]/g, ' ')
             .replace(/[:,]/g, ' ')
     );
+}
+
+function extractEmbeddedTextDetail(obj: Record<string, unknown>, keys: string[]) {
+    for (const value of Object.values(obj)) {
+        if (typeof value !== 'string') continue;
+        const detail = parseToolDetailText(value, keys);
+        if (detail) return detail;
+    }
+
+    return null;
+}
+
+export function parseToolDetail(toolName: string, rawInput: unknown) {
+    const keys = [...(TOOL_DETAIL_KEYS[toolName] || []), ...DEFAULT_DETAIL_KEYS];
+
+    if (rawInput && typeof rawInput === 'object' && !Array.isArray(rawInput)) {
+        const objectMatch = extractObjectDetail(rawInput as Record<string, unknown>, keys);
+        if (objectMatch) {
+            return objectMatch;
+        }
+
+        const embeddedTextMatch = extractEmbeddedTextDetail(rawInput as Record<string, unknown>, keys);
+        if (embeddedTextMatch) {
+            return embeddedTextMatch;
+        }
+    }
+
+    return parseToolDetailText(rawInput, keys);
 }
 
 export function formatToolLabel(toolName: string) {


### PR DESCRIPTION
## Summary

Addresses the remaining review nits from the ESM migration cleanup.

## Cause and effect

`parseToolDetail` handled object inputs before it attempted text regex or JSON parsing, so object-shaped wrappers containing JSON string payloads could fall back to low-value object text instead of the useful structured detail. Adapter JSONL utilities also remained in a `.js` file inside the TypeScript adapter directory, and the generated-JavaScript ignore list still contained broad legacy patterns that no longer match the current ESM migration shape.

While validating the full suite on Node 25, adapter tests also exposed stale `fs.rmdirSync(..., { recursive: true })` cleanup calls. Node 25 rejects that option, so those tests failed during cleanup even when the adapter behavior itself was correct.

## Fix

- Refactored `parseToolDetail` so object inputs first use known object detail keys, then inspect embedded string payloads through the same regex/JSON/text fallback path.
- Added a regression test for structured wrappers that contain JSON-string tool input.
- Renamed `claudeville/adapters/jsonl-utils.js` to `jsonl-utils.ts` and added explicit TypeScript annotations.
- Trimmed `.gitignore` to remove broad legacy `claudeville/**/*.js`, `frontend/**/*.js`, `hubreceiver/**/*.js`, and `collector/**/*.js` patterns.
- Confirmed `HubDataSource.test.ts` is complete under its current name by running it with the targeted infrastructure test set.
- Updated adapter test temp-directory cleanup from removed `fs.rmdirSync(..., { recursive: true })` behavior to `fs.rmSync(..., { recursive: true, force: true })` so the suite is green on current Node.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run test -- claudeville/src/config/toolFormatting.test.ts claudeville/adapters/jsonl-utils.test.ts claudeville/src/infrastructure/HubDataSource.test.ts`
- `npm run test -- claudeville/adapters/claude.test.ts claudeville/adapters/codex.test.ts claudeville/adapters/copilot.test.ts claudeville/adapters/gemini.test.ts claudeville/adapters/openclaw.test.ts`
- `npm run test` — 83 files / 949 tests passed
