### PR TITLE
[codex] Resolve DeepSeek review risk items

### DIFF
--- a/claudeville/server.test.ts
+++ b/claudeville/server.test.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import crypto from 'crypto';
 import { once } from 'events';
 import net from 'net';
 import path from 'path';
@@ -123,6 +124,106 @@ async function waitForText(url: string, predicate: (text: string) => boolean, ti
   throw new Error(`Timed out waiting for ${url}: ${lastError}`);
 }
 
+function createMaskedTextFrame(payload: string) {
+  const payloadBuffer = Buffer.from(payload);
+  const maskKey = Buffer.from([1, 2, 3, 4]);
+  const header = payloadBuffer.length < 126
+    ? Buffer.from([0x81, 0x80 | payloadBuffer.length])
+    : Buffer.from([0x81, 0x80 | 126, payloadBuffer.length >> 8, payloadBuffer.length & 0xff]);
+  const masked = Buffer.alloc(payloadBuffer.length);
+  for (let index = 0; index < payloadBuffer.length; index++) {
+    masked[index] = payloadBuffer[index] ^ maskKey[index % 4];
+  }
+  return Buffer.concat([header, maskKey, masked]);
+}
+
+function readServerTextFrames(
+  socket: net.Socket,
+  expectedCount: number,
+  predicate: (message: string) => boolean = () => true,
+  timeoutMs = 5000,
+) {
+  return new Promise<string[]>((resolve, reject) => {
+    const messages: string[] = [];
+    let buffer = Buffer.alloc(0);
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for ${expectedCount} websocket frame(s); received ${messages.length}`));
+    }, timeoutMs);
+
+    function cleanup() {
+      clearTimeout(timeout);
+      socket.off('data', onData);
+      socket.off('error', onError);
+    }
+
+    function onError(error: Error) {
+      cleanup();
+      reject(error);
+    }
+
+    function onData(chunk: Buffer) {
+      buffer = Buffer.concat([buffer, chunk]);
+      while (buffer.length >= 2) {
+        const secondByte = buffer[1];
+        let payloadLength = secondByte & 0x7f;
+        let offset = 2;
+        if (payloadLength === 126) {
+          if (buffer.length < 4) return;
+          payloadLength = buffer.readUInt16BE(2);
+          offset = 4;
+        } else if (payloadLength === 127) {
+          if (buffer.length < 10) return;
+          payloadLength = Number(buffer.readBigUInt64BE(2));
+          offset = 10;
+        }
+        if (buffer.length < offset + payloadLength) return;
+
+        const opcode = buffer[0] & 0x0f;
+        const payload = buffer.slice(offset, offset + payloadLength);
+        buffer = buffer.slice(offset + payloadLength);
+        const message = payload.toString('utf8');
+        if (opcode === 0x1 && predicate(message)) {
+          messages.push(message);
+          if (messages.length >= expectedCount) {
+            cleanup();
+            resolve(messages);
+            return;
+          }
+        }
+      }
+    }
+
+    socket.on('data', onData);
+    socket.on('error', onError);
+  });
+}
+
+async function connectWebSocket(port: number) {
+  const socket = net.connect(port, '127.0.0.1');
+  await once(socket, 'connect');
+  const key = crypto.randomBytes(16).toString('base64');
+  socket.write(
+    [
+      'GET / HTTP/1.1',
+      `Host: 127.0.0.1:${port}`,
+      'Upgrade: websocket',
+      'Connection: Upgrade',
+      `Sec-WebSocket-Key: ${key}`,
+      'Sec-WebSocket-Version: 13',
+      '\r\n',
+    ].join('\r\n'),
+  );
+
+  let handshake = Buffer.alloc(0);
+  while (!handshake.includes('\r\n\r\n')) {
+    const [chunk] = await once(socket, 'data') as [Buffer];
+    handshake = Buffer.concat([handshake, chunk]);
+  }
+  expect(handshake.toString('utf8')).toContain('101 Switching Protocols');
+  return socket;
+}
+
 describe('legacy server entrypoint', () => {
   it('serves runtime config, JSON APIs, and CORS headers on a configurable port', async () => {
     const port = await getFreePort();
@@ -155,6 +256,58 @@ describe('legacy server entrypoint', () => {
       const { stdout, stderr } = server.getOutput();
       throw new Error(`${error instanceof Error ? error.message : String(error)}\n\n[legacy stdout]\n${stdout}\n[legacy stderr]\n${stderr}`);
     } finally {
+      await stopProcess(server.child);
+    }
+  });
+
+  it('handles websocket text frames split across TCP chunks', async () => {
+    const port = await getFreePort();
+    const server = startTsx(legacyServerEntrypoint, {
+      PORT: String(port),
+    });
+    let socket: net.Socket | null = null;
+
+    try {
+      await waitForText(`http://127.0.0.1:${port}/runtime-config.js`, (text) => text.includes('window.__CLAUDEVILLE_CONFIG__'));
+      socket = await connectWebSocket(port);
+      const frame = createMaskedTextFrame(JSON.stringify({ type: 'ping' }));
+      const responseFrames = readServerTextFrames(socket, 1, (message) => JSON.parse(message).type === 'pong');
+      socket.write(frame.subarray(0, 3));
+      await delay(25);
+      socket.write(frame.subarray(3));
+
+      const [message] = await responseFrames;
+      expect(JSON.parse(message)).toMatchObject({ type: 'pong' });
+    } catch (error) {
+      const { stdout, stderr } = server.getOutput();
+      throw new Error(`${error instanceof Error ? error.message : String(error)}\n\n[legacy stdout]\n${stdout}\n[legacy stderr]\n${stderr}`);
+    } finally {
+      socket?.destroy();
+      await stopProcess(server.child);
+    }
+  });
+
+  it('handles multiple websocket text frames delivered in one TCP chunk', async () => {
+    const port = await getFreePort();
+    const server = startTsx(legacyServerEntrypoint, {
+      PORT: String(port),
+    });
+    let socket: net.Socket | null = null;
+
+    try {
+      await waitForText(`http://127.0.0.1:${port}/runtime-config.js`, (text) => text.includes('window.__CLAUDEVILLE_CONFIG__'));
+      socket = await connectWebSocket(port);
+      const frame = createMaskedTextFrame(JSON.stringify({ type: 'ping' }));
+      const responseFrames = readServerTextFrames(socket, 2, (message) => JSON.parse(message).type === 'pong');
+      socket.write(Buffer.concat([frame, frame]));
+
+      const messages = await responseFrames;
+      expect(messages.map((message) => JSON.parse(message).type)).toEqual(['pong', 'pong']);
+    } catch (error) {
+      const { stdout, stderr } = server.getOutput();
+      throw new Error(`${error instanceof Error ? error.message : String(error)}\n\n[legacy stdout]\n${stdout}\n[legacy stderr]\n${stderr}`);
+    } finally {
+      socket?.destroy();
       await stopProcess(server.child);
     }
   });

--- a/claudeville/server.ts
+++ b/claudeville/server.ts
@@ -338,6 +338,8 @@ async function sendInitialData(socket: WebSocket) {
 let watchDebounce: ReturnType<typeof setTimeout> | null = null;
 let broadcastInFlight = false;
 let broadcastPendingCount = 0;
+let fileWatcherCleanup: (() => void) | null = null;
+let pollingIntervalId: ReturnType<typeof setInterval> | null = null;
 
 async function broadcastUpdate() {
   if (wsClients.size === 0) return;
@@ -377,14 +379,29 @@ function debouncedBroadcast() {
 // ─── File watching (multi-provider) ────────────────────────
 
 function startFileWatcher() {
-  const { watchCount } = createFileWatchers(getAllWatchPaths(), debouncedBroadcast);
+  const watcherHandle = createFileWatchers(getAllWatchPaths(), debouncedBroadcast);
+  fileWatcherCleanup = watcherHandle.close;
+  const { watchCount } = watcherHandle;
   console.log(`[Watch] started watching ${watchCount} paths`);
 
   // Periodic polling (2s) - prevent missed updates
-  setInterval(() => {
+  pollingIntervalId = setInterval(() => {
     if (wsClients.size > 0) void broadcastUpdate();
   }, 2000);
   console.log('[Watch] polling started at 2s interval');
+}
+
+function stopFileWatcher() {
+  if (watchDebounce) {
+    clearTimeout(watchDebounce);
+    watchDebounce = null;
+  }
+  fileWatcherCleanup?.();
+  fileWatcherCleanup = null;
+  if (pollingIntervalId) {
+    clearInterval(pollingIntervalId);
+    pollingIntervalId = null;
+  }
 }
 
 // ─── HTTP server ──────────────────────────────────────────
@@ -513,6 +530,7 @@ process.on('unhandledRejection', (reason: unknown) => {
 
 process.on('SIGINT', () => {
   console.log('\nshutting down server...');
+  stopFileWatcher();
   for (const socket of wsClients) {
     try {
       socket.close();

--- a/claudeville/server.ts
+++ b/claudeville/server.ts
@@ -38,6 +38,13 @@ const ACTIVE_THRESHOLD_MS = 2 * 60 * 1000; // 2 minutes
 const wsServer = new WebSocketServer({ noServer: true });
 const wsClients = new Set<WebSocket>();
 
+function parseRequestUrl(req: HttpRequest) {
+  const host = req.headers.host && /^[A-Za-z0-9.:[\]-]+$/.test(req.headers.host)
+    ? req.headers.host
+    : `localhost:${PORT}`;
+  return new URL(req.url ?? '/', `http://${host}`);
+}
+
 // ─── API handlers ─────────────────────────────────────────
 
 /**
@@ -88,7 +95,7 @@ async function handleGetTasks(req: HttpRequest, res: HttpResponse) {
  */
 async function handleGetSessionDetail(req: HttpRequest, res: HttpResponse) {
   try {
-    const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+    const url = parseRequestUrl(req);
     const sessionId = url.searchParams.get('sessionId');
     const project = url.searchParams.get('project');
     const provider = url.searchParams.get('provider') || 'claude';
@@ -137,7 +144,7 @@ function handleGetUsage(req: HttpRequest, res: HttpResponse) {
  */
 async function handleGetHistory(req: HttpRequest, res: HttpResponse) {
   try {
-    const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+    const url = parseRequestUrl(req);
     const limit = safeLimit(url.searchParams.get('lines'));
     const sessions = await getAllSessions(ACTIVE_THRESHOLD_MS);
     const entries: { provider: string; sessionId: string; project: string | null; role: string; text: string; ts: number }[] = [];
@@ -414,7 +421,7 @@ const server = http.createServer((req: HttpRequest, res: HttpResponse) => {
     return;
   }
 
-  const parsedUrl = new URL(req.url ?? '/', `http://${req.headers.host}`);
+  const parsedUrl = parseRequestUrl(req);
   const pathname = parsedUrl.pathname;
 
   if (req.method === 'GET') {

--- a/claudeville/server.ts
+++ b/claudeville/server.ts
@@ -5,13 +5,12 @@ import * as net from 'net';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
+import { WebSocketServer, type WebSocket } from 'ws';
 
 import { buildRuntimeConfig } from '../runtime-config.shared.js';
 import { MIME_TYPES } from '../shared/mime-types.js';
 import { setCorsHeaders, sendJson, sendError, safeLimit } from '../shared/http-utils.js';
-import { createWebSocketFrame, computeAcceptKey } from '../shared/ws-utils.js';
 import { createFileWatchers } from '../shared/watch-utils.js';
-import { DISCONNECTED_CODES } from '../shared/ws-helpers.js';
 import {
   adapters,
   getAllSessions,
@@ -36,7 +35,8 @@ const STATIC_DIR = fs.existsSync(path.join(BUILT_FRONTEND_DIR, 'index.html')) ? 
 const ACTIVE_THRESHOLD_MS = 2 * 60 * 1000; // 2 minutes
 
 // ─── WebSocket client management ──────────────────────────
-const wsClients = new Set<net.Socket>();
+const wsServer = new WebSocketServer({ noServer: true });
+const wsClients = new Set<WebSocket>();
 
 // ─── API handlers ─────────────────────────────────────────
 
@@ -227,138 +227,51 @@ function handleRuntimeConfig(req: HttpRequest, res: HttpResponse) {
   res.end(`window.__CLAUDEVILLE_CONFIG__ = ${JSON.stringify(runtimeConfig)};\n`);
 }
 
-// ─── WebSocket implementation (RFC 6455) ──────────────────────────
+// ─── WebSocket implementation ──────────────────────────
 
-function handleWebSocketUpgrade(req: HttpRequest, socket: net.Socket) {
-  const key = req.headers['sec-websocket-key'];
-  if (!key) {
-    socket.destroy();
-    return;
-  }
-
-  const acceptKey = computeAcceptKey(key);
-
-  const responseStr =
-    'HTTP/1.1 101 Switching Protocols\r\n' +
-    'Upgrade: websocket\r\n' +
-    'Connection: Upgrade\r\n' +
-    'Sec-WebSocket-Accept: ' + acceptKey + '\r\n' +
-    '\r\n';
-
-  socket.write(responseStr, () => {
-    wsClients.add(socket);
-    setTimeout(() => {
-      if (!socket.destroyed && socket.writable && wsClients.has(socket)) {
-        void sendInitialData(socket);
-      }
-    }, 100);
-  });
-
-  socket.on('data', (buffer: Buffer) => {
-    try {
-      handleWebSocketFrame(socket, buffer);
-    } catch (err: unknown) {
-      reportWebSocketFrameIssue(socket, 'frame handling error', err);
+function handleWebSocketConnection(socket: WebSocket) {
+  wsClients.add(socket);
+  setTimeout(() => {
+    if (socket.readyState === socket.OPEN && wsClients.has(socket)) {
+      void sendInitialData(socket);
     }
+  }, 100);
+
+  socket.on('message', (data) => {
+    const message = typeof data === 'string' ? data : data.toString('utf8');
+    handleTextMessage(socket, message);
   });
 
   socket.on('close', () => {
     wsClients.delete(socket);
   });
 
-  socket.on('error', () => {
+  socket.on('error', (err) => {
+    console.error('[WebSocket] socket error:', err.message);
     wsClients.delete(socket);
   });
 }
 
-function handleWebSocketFrame(socket: net.Socket, buffer: Buffer) {
-  if (buffer.length < 2) return;
-
-  const firstByte = buffer[0];
-  const secondByte = buffer[1];
-
-  const opcode = firstByte & 0x0f;
-  const isMasked = (secondByte & 0x80) !== 0;
-  let payloadLength = secondByte & 0x7f;
-  let offset = 2;
-
-  if (!isMasked) {
-    reportWebSocketFrameIssue(socket, 'client frame was not masked');
-    return;
-  }
-
-  if (payloadLength === 126) {
-    if (buffer.length < 4) return;
-    payloadLength = buffer.readUInt16BE(2);
-    offset = 4;
-  } else if (payloadLength === 127) {
-    if (buffer.length < 10) return;
-    payloadLength = Number(buffer.readBigUInt64BE(2));
-    offset = 10;
-  }
-
-  // Guard: reject frames larger than 100MB to prevent memory exhaustion
-  if (payloadLength > 100 * 1024 * 1024) {
-    reportWebSocketFrameIssue(socket, `frame too large: ${payloadLength} bytes`);
-    return;
-  }
-
-  if (buffer.length < offset + 4) return;
-  const maskKey = buffer.slice(offset, offset + 4);
-  offset += 4;
-
-  if (buffer.length < offset + payloadLength) return;
-
-  const payload = buffer.slice(offset, offset + payloadLength);
-  for (let i = 0; i < payload.length; i++) {
-    payload[i] ^= maskKey[i % 4];
-  }
-
-  switch (opcode) {
-    case 0x1:
-      handleTextMessage(socket, payload.toString('utf-8'));
-      break;
-    case 0x8:
-      try {
-        socket.end(createWebSocketFrame('', 0x8));
-      } catch {
-        socket.destroy();
-      }
-      wsClients.delete(socket);
-      break;
-    case 0x9:
-      try {
-        socket.write(createWebSocketFrame(payload, 0xa));
-      } catch {
-        reportWebSocketFrameIssue(socket, `pong frame creation failed`);
-      }
-      break;
-    case 0xa:
-      break;
-    default:
-      reportWebSocketFrameIssue(socket, `unsupported opcode 0x${opcode.toString(16)}`);
-      break;
-  }
-}
-
-function handleTextMessage(socket: net.Socket, message: string) {
+function handleTextMessage(socket: WebSocket, message: string) {
   try {
     const data = JSON.parse(message);
     if (data.type === 'ping') {
       wsSend(socket, { type: 'pong', timestamp: Date.now() });
     }
   } catch (err: unknown) {
-    reportWebSocketFrameIssue(socket, 'invalid JSON text frame', err);
+    console.warn('[WebSocket] invalid JSON text frame:', err instanceof Error ? err.message : String(err));
   }
 }
 
-function wsSend(socket: net.Socket, data: unknown) {
+function wsSend(socket: WebSocket, data: unknown) {
   try {
-    if (!socket.destroyed && socket.writable) {
-      const frame = createWebSocketFrame(JSON.stringify(data));
-      if (!socket.write(frame)) {
-        console.error('[WebSocket] write returned false, buffer full');
-      }
+    if (socket.readyState === socket.OPEN) {
+      socket.send(JSON.stringify(data), (err) => {
+        if (err) {
+          console.error('[WebSocket] send error:', err.message);
+          wsClients.delete(socket);
+        }
+      });
     } else {
       wsClients.delete(socket);
     }
@@ -370,66 +283,41 @@ function wsSend(socket: net.Socket, data: unknown) {
 }
 
 function wsBroadcast(data: unknown) {
-  let frame: Buffer;
+  let payload: string;
   try {
-    frame = createWebSocketFrame(JSON.stringify(data));
+    payload = JSON.stringify(data);
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
-    console.error(`[WebSocket] broadcast frame creation failed: ${msg}`);
+    console.error(`[WebSocket] broadcast payload creation failed: ${msg}`);
     return;
   }
 
-  const deadSockets: net.Socket[] = [];
+  const deadSockets: WebSocket[] = [];
   for (const socket of wsClients) {
-    try {
-      if (!socket.destroyed && socket.writable) {
-        if (!socket.write(frame)) {
-          deadSockets.push(socket);
-        }
-      } else {
-        deadSockets.push(socket);
-      }
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error(`[WebSocket] broadcast error: ${msg}`);
+    if (socket.readyState !== socket.OPEN) {
       deadSockets.push(socket);
+      continue;
     }
+    socket.send(payload, (err) => {
+      if (err) {
+        console.error('[WebSocket] broadcast error:', err.message);
+        wsClients.delete(socket);
+        try {
+          socket.close();
+        } catch {
+          // ignore close failures
+        }
+      }
+    });
   }
-  // Clean up dead sockets
   for (const socket of deadSockets) {
-    wsClients.delete(socket);
-  }
-}
-
-const WS_FRAME_ISSUE_WINDOW_MS = 5000;
-const WS_FRAME_ISSUE_CLOSE_THRESHOLD = 3;
-
-function reportWebSocketFrameIssue(socket: net.Socket, reason: string, err?: unknown) {
-  const now = Date.now();
-  const state = (socket as unknown as { _claudevilleWsFrameIssue?: { count: number; lastLoggedAt: number } })._claudevilleWsFrameIssue || { count: 0, lastLoggedAt: 0 };
-  state.count += 1;
-
-  if (state.count === 1 || now - state.lastLoggedAt >= WS_FRAME_ISSUE_WINDOW_MS) {
-    const suffix = err ? `: ${err instanceof Error ? err.message : String(err)}` : '';
-    console.warn(`[WebSocket] ${reason}${suffix}`);
-    state.lastLoggedAt = now;
-  }
-
-  (socket as unknown as { _claudevilleWsFrameIssue: { count: number; lastLoggedAt: number } })._claudevilleWsFrameIssue = state;
-
-  if (state.count >= WS_FRAME_ISSUE_CLOSE_THRESHOLD && !socket.destroyed) {
-    try {
-      socket.end(createWebSocketFrame('', 0x8));
-    } catch {
-      socket.destroy();
-    }
     wsClients.delete(socket);
   }
 }
 
 // ─── Data broadcast ────────────────────────────────
 
-async function sendInitialData(socket: net.Socket) {
+async function sendInitialData(socket: WebSocket) {
   try {
     const [sessions, teams] = await Promise.all([
       getAllSessions(ACTIVE_THRESHOLD_MS),
@@ -442,8 +330,8 @@ async function sendInitialData(socket: net.Socket) {
       usage: usageQuota.fetchUsage(),
       timestamp: Date.now(),
     });
-  } catch {
-    // ignore initial data send failure
+  } catch (err: unknown) {
+    console.error('[WebSocket] initial data send failed:', err instanceof Error ? err.message : String(err));
   }
 }
 
@@ -550,7 +438,9 @@ const server = http.createServer((req: HttpRequest, res: HttpResponse) => {
 
 server.on('upgrade', (req: HttpRequest, socket: net.Socket, head: Buffer) => {
   if (req.headers.upgrade && req.headers.upgrade.toLowerCase() === 'websocket') {
-    handleWebSocketUpgrade(req, socket);
+    wsServer.handleUpgrade(req, socket, head, (websocket) => {
+      handleWebSocketConnection(websocket);
+    });
   } else {
     socket.destroy();
   }
@@ -625,7 +515,7 @@ process.on('SIGINT', () => {
   console.log('\nshutting down server...');
   for (const socket of wsClients) {
     try {
-      socket.end(createWebSocketFrame('', 0x8));
+      socket.close();
     } catch { /* ignore */ }
   }
   server.close(() => {

--- a/claudeville/src/main.tsx
+++ b/claudeville/src/main.tsx
@@ -1,5 +1,6 @@
 import { createRoot } from 'react-dom/client';
 
+import { ErrorBoundary } from './presentation/react/ErrorBoundary.js';
 import { ClaudeVilleApp } from './presentation/react/ClaudeVilleApp.js';
 
 const rootElement = document.getElementById('root');
@@ -9,5 +10,7 @@ if (!rootElement) {
 }
 
 createRoot(rootElement).render(
-  <ClaudeVilleApp />,
+  <ErrorBoundary>
+    <ClaudeVilleApp />
+  </ErrorBoundary>,
 );

--- a/claudeville/src/presentation/react/ErrorBoundary.test.tsx
+++ b/claudeville/src/presentation/react/ErrorBoundary.test.tsx
@@ -1,0 +1,31 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import { ErrorBoundary } from './ErrorBoundary.js';
+
+function BrokenChild() {
+  throw new Error('render exploded');
+  return null;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('ErrorBoundary', () => {
+  it('renders a fallback when a child throws during render', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <BrokenChild />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('RENDER FAILED')).toBeInTheDocument();
+    expect(screen.getByText('render exploded')).toBeInTheDocument();
+  });
+});

--- a/claudeville/src/presentation/react/ErrorBoundary.tsx
+++ b/claudeville/src/presentation/react/ErrorBoundary.tsx
@@ -1,0 +1,36 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type ErrorBoundaryState = {
+  error: Error | null;
+};
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = {
+    error: null,
+  };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('[React] render failed:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="boot-error">
+          <div>RENDER FAILED</div>
+          <div className="boot-error__detail">{this.state.error.message}</div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/claudeville/src/presentation/react/world/components/AgentActor.test.tsx
+++ b/claudeville/src/presentation/react/world/components/AgentActor.test.tsx
@@ -1,0 +1,62 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+
+import type { BubbleConfig } from '../types.js';
+import { Accessory, Bubble, Hair, NameTag } from './AgentActor.js';
+import { createPolygonGeometry, createRoundedRectGeometry } from '../utils.js';
+
+vi.mock('../utils.js', () => ({
+  createPolygonGeometry: vi.fn(() => ({ type: 'polygon-geometry' })),
+  createRoundedRectGeometry: vi.fn(() => ({ type: 'rounded-rect-geometry' })),
+}));
+
+vi.mock('./WorldText.js', () => ({
+  WorldText: ({ children }: { children: string }) => <span>{children}</span>,
+}));
+
+const bubbleConfig: BubbleConfig = {
+  textScale: 1,
+  statusFontSize: 14,
+  statusMaxWidth: 260,
+  statusBubbleH: 28,
+  statusPaddingH: 24,
+  chatFontSize: 14,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('AgentActor geometry creation', () => {
+  it('reuses bubble geometry while dimensions are stable', () => {
+    const { rerender } = render(<Bubble text="working" accentColor="#4ade80" bubbleConfig={bubbleConfig} inverseZoom={1} />);
+
+    rerender(<Bubble text="working" accentColor="#4ade80" bubbleConfig={bubbleConfig} inverseZoom={1} />);
+
+    expect(createRoundedRectGeometry).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses nametag and accessory polygon geometries while props are stable', () => {
+    const { rerender } = render(
+      <>
+        <NameTag name="Agent One" inverseZoom={1} />
+        <Hair style="spiky" color="#222222" />
+        <Accessory type="crown" />
+      </>,
+    );
+
+    rerender(
+      <>
+        <NameTag name="Agent One" inverseZoom={1} />
+        <Hair style="spiky" color="#222222" />
+        <Accessory type="crown" />
+      </>,
+    );
+
+    expect(createRoundedRectGeometry).toHaveBeenCalledTimes(1);
+    expect(createPolygonGeometry).toHaveBeenCalledTimes(2);
+  });
+});

--- a/claudeville/src/presentation/react/world/components/AgentActor.tsx
+++ b/claudeville/src/presentation/react/world/components/AgentActor.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import type { MutableRefObject } from 'react';
 
 import { useFrame } from '@react-three/fiber';
@@ -11,7 +11,7 @@ import type { BubbleConfig, CameraModel } from '../types.js';
 import { createPolygonGeometry, createRoundedRectGeometry } from '../utils.js';
 import { WorldText } from './WorldText.js';
 
-function Bubble({
+export function Bubble({
   text,
   accentColor,
   bubbleConfig,
@@ -27,7 +27,10 @@ function Bubble({
   const maxChars = Math.max(8, Math.floor((bubbleConfig.statusMaxWidth - bubbleConfig.statusPaddingH) / (bubbleConfig.statusFontSize * 0.56)));
   const displayText = text.length > maxChars ? `${text.slice(0, Math.max(1, maxChars - 1))}…` : text;
   const width = Math.min(displayText.length * bubbleConfig.statusFontSize * 0.56 + bubbleConfig.statusPaddingH, bubbleConfig.statusMaxWidth);
-  const geometry = createRoundedRectGeometry(width, bubbleConfig.statusBubbleH, 6);
+  const geometry = useMemo(
+    () => createRoundedRectGeometry(width, bubbleConfig.statusBubbleH, 6),
+    [bubbleConfig.statusBubbleH, width],
+  );
 
   return (
     <group position={[0, y, 0.2]} scale={[inverseZoom, inverseZoom, 1]}>
@@ -54,9 +57,9 @@ function Bubble({
   );
 }
 
-function NameTag({ name, inverseZoom }: { name: string; inverseZoom: number }) {
+export function NameTag({ name, inverseZoom }: { name: string; inverseZoom: number }) {
   const width = Math.max(name.length * 6 + 14, 48);
-  const geometry = createRoundedRectGeometry(width, 16, 4);
+  const geometry = useMemo(() => createRoundedRectGeometry(width, 16, 4), [width]);
 
   return (
     <group position={[0, 24, 0.2]} scale={[inverseZoom, inverseZoom, 1]}>
@@ -92,7 +95,9 @@ function ChatIndicator({ bubbleConfig, inverseZoom }: { bubbleConfig: BubbleConf
   );
 }
 
-function Hair({ style, color }: { style: string; color: string }) {
+export function Hair({ style, color }: { style: string; color: string }) {
+  const spikyGeometry = useMemo(() => createPolygonGeometry([[-4, 4], [-2, -2], [0, 3], [2, -2], [4, 4]]), []);
+
   switch (style) {
     case 'long':
       return (
@@ -113,7 +118,7 @@ function Hair({ style, color }: { style: string; color: string }) {
       );
     case 'spiky':
       return (
-        <mesh position={[0, -12, 0.1]} geometry={createPolygonGeometry([[-4, 4], [-2, -2], [0, 3], [2, -2], [4, 4]])}>
+        <mesh position={[0, -12, 0.1]} geometry={spikyGeometry}>
           <meshBasicMaterial color={color} toneMapped={false} side={THREE.DoubleSide} />
         </mesh>
       );
@@ -167,11 +172,13 @@ function Eyes({ style }: { style: string }) {
   );
 }
 
-function Accessory({ type }: { type: string }) {
+export function Accessory({ type }: { type: string }) {
+  const crownGeometry = useMemo(() => createPolygonGeometry([[-4, 3], [-4, 0], [-2, 2], [0, -1], [2, 2], [4, 0], [4, 3]]), []);
+
   switch (type) {
     case 'crown':
       return (
-        <mesh position={[0, -15, 0.12]} geometry={createPolygonGeometry([[-4, 3], [-4, 0], [-2, 2], [0, -1], [2, 2], [4, 0], [4, 3]])}>
+        <mesh position={[0, -15, 0.12]} geometry={crownGeometry}>
           <meshBasicMaterial color="#ffd700" toneMapped={false} side={THREE.DoubleSide} />
         </mesh>
       );

--- a/collector/index.real.test.ts
+++ b/collector/index.real.test.ts
@@ -60,13 +60,14 @@ function createHarness(createCollectorRuntime: CollectorModule['createCollectorR
   let watcherCallback: (() => void) | undefined;
   let intervalCallback: (() => void) | undefined;
   let nextTimeoutId = 1;
+  const watcherClose = vi.fn();
 
   const timeoutCallbacks = new Map<number, () => void>();
   const signalHandlers = new Map<string, () => void>();
   const fetchMock = options.fetchMock ?? vi.fn().mockResolvedValue({ ok: true, status: 202, statusText: 'Accepted' });
   const createFileWatchers = vi.fn((paths: string[], onChange: () => void) => {
     watcherCallback = onChange;
-    return { watchCount: paths.length };
+    return { watchCount: paths.length, close: watcherClose };
   });
   const getAllSessions = vi.fn().mockResolvedValue(options.sessions ?? []);
   const getAllWatchPaths = vi.fn().mockReturnValue(options.watchPaths ?? ['/tmp/provider-a']);
@@ -87,6 +88,7 @@ function createHarness(createCollectorRuntime: CollectorModule['createCollectorR
     intervalCallback = callback;
     return 1 as unknown as ReturnType<typeof setInterval>;
   });
+  const clearIntervalSpy = vi.fn();
   const setTimeoutSpy = vi.fn((callback: () => void) => {
     const timerId = nextTimeoutId++;
     timeoutCallbacks.set(timerId, () => {
@@ -114,6 +116,7 @@ function createHarness(createCollectorRuntime: CollectorModule['createCollectorR
       setTimeout: setTimeoutSpy as typeof setTimeout,
       clearTimeout: clearTimeoutSpy as typeof clearTimeout,
       setInterval: setIntervalSpy as typeof setInterval,
+      clearInterval: clearIntervalSpy as typeof clearInterval,
       console: { log: logSpy, error: errorSpy },
       process: { on: processOnSpy as typeof process.on, exit: processExitSpy as typeof process.exit },
     },
@@ -131,6 +134,7 @@ function createHarness(createCollectorRuntime: CollectorModule['createCollectorR
     runtime,
     fetchMock,
     createFileWatchers,
+    watcherClose,
     getAllSessions,
     getSessionDetailByProvider,
     logSpy,
@@ -138,6 +142,7 @@ function createHarness(createCollectorRuntime: CollectorModule['createCollectorR
     processOnSpy,
     processExitSpy,
     setIntervalSpy,
+    clearIntervalSpy,
     setTimeoutSpy,
     clearTimeoutSpy,
     timeoutCallbacks,
@@ -279,8 +284,11 @@ describe('collector/index.ts real module coverage', () => {
     harness.signalHandlers.get('SIGTERM')?.();
 
     expect(harness.clearTimeoutSpy).toHaveBeenLastCalledWith(pendingTimerId as unknown as ReturnType<typeof setTimeout>);
-    expect(harness.processExitSpy).toHaveBeenNthCalledWith(1, 0);
-    expect(harness.processExitSpy).toHaveBeenNthCalledWith(2, 0);
+    expect(harness.watcherClose).toHaveBeenCalledTimes(1);
+    expect(harness.clearIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(harness.clearIntervalSpy).toHaveBeenCalledWith(1);
+    expect(harness.processExitSpy).toHaveBeenCalledTimes(1);
+    expect(harness.processExitSpy).toHaveBeenCalledWith(0);
   });
 
   it('keeps dirty state on failures and retries after an in-flight publish finishes', async () => {

--- a/collector/index.real.test.ts
+++ b/collector/index.real.test.ts
@@ -60,6 +60,7 @@ function createHarness(createCollectorRuntime: CollectorModule['createCollectorR
   let watcherCallback: (() => void) | undefined;
   let intervalCallback: (() => void) | undefined;
   let nextTimeoutId = 1;
+  let nextIntervalId = 1;
   const watcherClose = vi.fn();
 
   const timeoutCallbacks = new Map<number, () => void>();
@@ -84,11 +85,19 @@ function createHarness(createCollectorRuntime: CollectorModule['createCollectorR
     return process;
   });
   const processExitSpy = vi.fn();
+  const intervalCallbacks = new Map<number, () => void>();
   const setIntervalSpy = vi.fn((callback: () => void) => {
+    const intervalId = nextIntervalId++;
     intervalCallback = callback;
-    return 1 as unknown as ReturnType<typeof setInterval>;
+    intervalCallbacks.set(intervalId, callback);
+    return intervalId as unknown as ReturnType<typeof setInterval>;
   });
-  const clearIntervalSpy = vi.fn();
+  const clearIntervalSpy = vi.fn((timer: ReturnType<typeof setInterval>) => {
+    intervalCallbacks.delete(Number(timer));
+    if (intervalCallbacks.size === 0) {
+      intervalCallback = undefined;
+    }
+  });
   const setTimeoutSpy = vi.fn((callback: () => void) => {
     const timerId = nextTimeoutId++;
     timeoutCallbacks.set(timerId, () => {
@@ -146,6 +155,7 @@ function createHarness(createCollectorRuntime: CollectorModule['createCollectorR
     setTimeoutSpy,
     clearTimeoutSpy,
     timeoutCallbacks,
+    intervalCallbacks,
     signalHandlers,
     get watcherCallback() {
       return watcherCallback;
@@ -287,6 +297,8 @@ describe('collector/index.ts real module coverage', () => {
     expect(harness.watcherClose).toHaveBeenCalledTimes(1);
     expect(harness.clearIntervalSpy).toHaveBeenCalledTimes(1);
     expect(harness.clearIntervalSpy).toHaveBeenCalledWith(1);
+    expect(harness.intervalCallbacks.size).toBe(0);
+    expect(harness.intervalCallback).toBeUndefined();
     expect(harness.processExitSpy).toHaveBeenCalledTimes(1);
     expect(harness.processExitSpy).toHaveBeenCalledWith(0);
   });

--- a/collector/index.ts
+++ b/collector/index.ts
@@ -20,7 +20,7 @@ type CollectorRuntimeConfig = {
 };
 
 type CollectorRuntimeDeps = {
-  createFileWatchers: (paths: WatchPath[], onChange: () => void) => { watchCount: number };
+  createFileWatchers: (paths: WatchPath[], onChange: () => void) => { watchCount: number; close?: () => void };
   createHash: typeof crypto.createHash;
   adapters: Array<{
     provider?: string;
@@ -35,6 +35,7 @@ type CollectorRuntimeDeps = {
   setTimeout: typeof globalThis.setTimeout;
   clearTimeout: typeof globalThis.clearTimeout;
   setInterval: typeof globalThis.setInterval;
+  clearInterval: typeof globalThis.clearInterval;
   console: { log: (...args: unknown[]) => void; error: (...args: unknown[]) => void };
   process: Pick<typeof process, 'on' | 'exit'>;
 };
@@ -72,6 +73,7 @@ const defaultCollectorDeps: CollectorRuntimeDeps = {
   setTimeout: globalThis.setTimeout,
   clearTimeout: globalThis.clearTimeout,
   setInterval: globalThis.setInterval,
+  clearInterval: globalThis.clearInterval,
   console,
   process,
 };
@@ -109,9 +111,14 @@ export function createCollectorRuntime(
     },
     buildSnapshot,
   );
+  let watcherCleanup: (() => void) | null = null;
+  let intervalId: ReturnType<typeof globalThis.setInterval> | null = null;
+  let shuttingDown = false;
 
   function startWatchers() {
-    const { watchCount } = deps.createFileWatchers(deps.getAllWatchPaths(), publisher.scheduleFlush);
+    const watcherHandle = deps.createFileWatchers(deps.getAllWatchPaths(), publisher.scheduleFlush);
+    watcherCleanup = watcherHandle.close ?? null;
+    const { watchCount } = watcherHandle;
     deps.console.log(`[collector] watching ${watchCount} path(s)`);
   }
 
@@ -119,12 +126,22 @@ export function createCollectorRuntime(
     startWatchers();
     await publisher.publishSnapshot();
 
-    deps.setInterval(() => {
+    intervalId = deps.setInterval(() => {
       void publisher.publishSnapshot();
     }, config.flushIntervalMs);
   }
 
   function shutdown() {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    if (watcherCleanup) {
+      watcherCleanup();
+      watcherCleanup = null;
+    }
+    if (intervalId) {
+      deps.clearInterval(intervalId);
+      intervalId = null;
+    }
     publisher.clearFlushTimer();
     deps.process.exit(0);
   }

--- a/collector/publisher.test.ts
+++ b/collector/publisher.test.ts
@@ -12,6 +12,13 @@ describe('collector publisher', () => {
     expect(computeSnapshotFingerprint(snapshot, createHash)).toBe(computeSnapshotFingerprint(snapshot, createHash));
   });
 
+  it('ignores volatile snapshot timestamps when computing fingerprints', () => {
+    const snapshot1 = { collectorId: 'c1', timestamp: 1000, sessions: [{ sessionId: 's1' }] };
+    const snapshot2 = { collectorId: 'c1', timestamp: 2000, sessions: [{ sessionId: 's1' }] };
+
+    expect(computeSnapshotFingerprint(snapshot1, createHash)).toBe(computeSnapshotFingerprint(snapshot2, createHash));
+  });
+
   it('publishes a snapshot once until a flush marks it dirty again', async () => {
     const snapshot = { collectorId: 'c1', sessions: [{ sessionId: 's1' }] };
     const buildSnapshot = vi.fn().mockResolvedValue(snapshot);

--- a/collector/publisher.ts
+++ b/collector/publisher.ts
@@ -7,7 +7,9 @@ interface SnapshotWithSessions {
 }
 
 export function computeSnapshotFingerprint(snapshot: object, createHash: typeof crypto.createHash): string {
-  return createHash('sha1').update(JSON.stringify(snapshot)).digest('hex');
+  const stableSnapshot = { ...snapshot };
+  delete (stableSnapshot as { timestamp?: unknown }).timestamp;
+  return createHash('sha1').update(JSON.stringify(stableSnapshot)).digest('hex');
 }
 
 export async function sendCollectorSnapshot(snapshot: object, config: { hubUrl: string; hubAuthToken: string }, fetchFn: (url: string, options: { method: string; headers: Record<string, string>; body: string }) => Promise<{ ok: boolean; status: number; statusText: string }>): Promise<void> {

--- a/collector/snapshot.test.ts
+++ b/collector/snapshot.test.ts
@@ -121,4 +121,36 @@ describe('collector snapshot helpers', () => {
       'copilot:s2': { tokenUsage: { input: 3, output: 4 } },
     });
   });
+
+  it('keeps building a snapshot when one session detail lookup fails', async () => {
+    const getAllSessions = vi.fn().mockResolvedValue([
+      { provider: 'claude', sessionId: 's1', project: '/repo/one', model: 'claude-sonnet-4-5', tokens: { input: 10, output: 5 } },
+      { provider: 'copilot', sessionId: 's2', project: '/repo/two', model: 'claude-haiku-4-5' },
+    ]);
+    const getSessionDetailByProvider = vi.fn()
+      .mockRejectedValueOnce(new Error('detail file disappeared'))
+      .mockResolvedValueOnce({ tokenUsage: { input: 3, output: 4 } });
+
+    const snapshot = await buildCollectorSnapshot(
+      {
+        getAllSessions,
+        getSessionDetailByProvider,
+        getActiveProviders: () => [],
+      },
+      {
+        collectorId: 'collector-1',
+        collectorHost: 'host-1',
+        activeThresholdMs: 120000,
+      },
+    );
+
+    expect(snapshot.sessions.map((session) => session.sessionId)).toEqual(['s1', 's2']);
+    expect(snapshot.sessions[0].tokens).toEqual({ input: 10, output: 5 });
+    expect(snapshot.sessions[0].tokenUsage).toBeNull();
+    expect(snapshot.sessions[1].tokens).toEqual({ input: 3, output: 4 });
+    expect(snapshot.sessionDetails).toEqual({
+      'claude:s1': null,
+      'copilot:s2': { tokenUsage: { input: 3, output: 4 } },
+    });
+  });
 });

--- a/collector/snapshot.test.ts
+++ b/collector/snapshot.test.ts
@@ -69,4 +69,56 @@ describe('collector snapshot helpers', () => {
     expect(snapshot.sessionDetails['claude:s1']).toEqual({ tokenUsage: { totalInput: 100, totalOutput: 20 } });
     expect(snapshot.sessions[0]).toHaveProperty('estimatedCost');
   });
+
+  it('fetches missing session details in parallel while preserving session order', async () => {
+    let firstLookupStarted = false;
+    let secondLookupStarted = false;
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+
+    const getAllSessions = vi.fn().mockResolvedValue([
+      { provider: 'claude', sessionId: 's1', project: '/repo/one', model: 'claude-sonnet-4-5' },
+      { provider: 'copilot', sessionId: 's2', project: '/repo/two', model: 'claude-haiku-4-5' },
+    ]);
+    const getSessionDetailByProvider = vi.fn().mockImplementation((provider: string) => {
+      if (provider === 'claude') {
+        firstLookupStarted = true;
+        return new Promise((resolve) => {
+          releaseFirst = () => resolve({ tokenUsage: { input: 1, output: 2 } });
+        });
+      }
+      secondLookupStarted = true;
+      expect(firstLookupStarted).toBe(true);
+      return new Promise((resolve) => {
+        releaseSecond = () => resolve({ tokenUsage: { input: 3, output: 4 } });
+      });
+    });
+
+    const snapshotPromise = buildCollectorSnapshot(
+      {
+        getAllSessions,
+        getSessionDetailByProvider,
+        getActiveProviders: () => [],
+      },
+      {
+        collectorId: 'collector-1',
+        collectorHost: 'host-1',
+        activeThresholdMs: 120000,
+      },
+    );
+
+    await Promise.resolve();
+    expect(secondLookupStarted).toBe(true);
+
+    releaseSecond();
+    await Promise.resolve();
+    releaseFirst();
+
+    const snapshot = await snapshotPromise;
+    expect(snapshot.sessions.map((session) => session.sessionId)).toEqual(['s1', 's2']);
+    expect(snapshot.sessionDetails).toEqual({
+      'claude:s1': { tokenUsage: { input: 1, output: 2 } },
+      'copilot:s2': { tokenUsage: { input: 3, output: 4 } },
+    });
+  });
 });

--- a/collector/snapshot.ts
+++ b/collector/snapshot.ts
@@ -50,18 +50,17 @@ export function normalizeSession(session: SessionSummary, detail: SessionDetail 
 }
 
 export async function buildCollectorSnapshot(deps: CollectorSnapshotDeps, config: CollectorSnapshotConfig) {
-  const normalizedSessions = [];
   const sessionDetails: Record<string, SessionDetail | null> = {};
 
   const activeSessions = await deps.getAllSessions(config.activeThresholdMs);
-  for (const session of activeSessions) {
+  const normalizedSessions = await Promise.all(activeSessions.map(async (session) => {
     const detail = session.detail || await deps.getSessionDetailByProvider(session.provider, session.sessionId, session.project ?? null);
     const normalized = normalizeSession(session, detail);
-    normalizedSessions.push(normalized);
 
     const key = `${session.provider}:${session.sessionId}`;
     sessionDetails[key] = detail;
-  }
+    return normalized;
+  }));
 
   const [teams, taskGroups] = await Promise.all([
     deps.claudeAdapter?.getTeams?.() || [],

--- a/collector/snapshot.ts
+++ b/collector/snapshot.ts
@@ -54,7 +54,14 @@ export async function buildCollectorSnapshot(deps: CollectorSnapshotDeps, config
 
   const activeSessions = await deps.getAllSessions(config.activeThresholdMs);
   const normalizedSessions = await Promise.all(activeSessions.map(async (session) => {
-    const detail = session.detail || await deps.getSessionDetailByProvider(session.provider, session.sessionId, session.project ?? null);
+    let detail: SessionDetail | null = session.detail || null;
+    if (!detail) {
+      try {
+        detail = await deps.getSessionDetailByProvider(session.provider, session.sessionId, session.project ?? null);
+      } catch {
+        detail = null;
+      }
+    }
     const normalized = normalizeSession(session, detail);
 
     const key = `${session.provider}:${session.sessionId}`;

--- a/docs/architecture/000-overall-spec.md
+++ b/docs/architecture/000-overall-spec.md
@@ -176,7 +176,11 @@ The branch introduces the following major architectural changes:
 
 ## Constraints
 
-- no external npm dependencies
+- Prefer platform-native APIs for simple local behavior, but established frameworks,
+  libraries, and npm dependencies are allowed when they reduce protocol risk,
+  security risk, maintenance burden, or implementation complexity. New
+  dependencies should be narrowly scoped, actively maintained, and covered by
+  tests around the ClaudeVille integration points.
 - ES modules in `src/`
 - CommonJS in server / adapter entrypoints
 - port `4000` remains the legacy app default

--- a/docs/deepseek-review.md
+++ b/docs/deepseek-review.md
@@ -148,3 +148,58 @@ Both the legacy server (`claudeville/server.ts`) and the hubreceiver (`hubreceiv
 3. **R3F GPU resource leaks** — geometry allocation per render without disposal
 4. **Test coverage gaps** — core adapters and collector runtime effectively untested
 5. **Graceful shutdown** — file watchers, intervals, and sockets are never cleaned up outside process exit
+
+---
+
+## Implementation Status
+
+Updated on 26 April 2026 by `codex/plan-deepseek-review-fixes`.
+
+### Fixed In This Branch
+
+- **WebSocket frame correctness:** Replaced the legacy hand-rolled WebSocket frame parser/sender in `claudeville/server.ts` with the maintained `ws` package in `noServer` mode. Added raw TCP regression tests for fragmented client frames and multiple frames delivered in a single TCP chunk.
+- **WebSocket diagnostics and backpressure behavior:** Legacy WebSocket socket errors and initial-data failures are now logged. `ws` owns protocol parsing, buffering, ping/pong handling, and send callbacks instead of the server dropping sockets based on raw `write()` return values.
+- **Watcher lifecycle cleanup:** `shared/watch-utils.js` now returns watcher handles and an idempotent `close()` function. The collector and legacy server retain watcher/interval handles and clear them during shutdown.
+- **Collector interval cleanup:** `collector/index.ts` stores and clears its periodic publish interval during shutdown.
+- **Collector detail fetch concurrency:** `collector/snapshot.ts` fetches missing session details with `Promise.all` while preserving output order.
+- **React error boundary:** Added a top-level `ErrorBoundary` around `ClaudeVilleApp` in `claudeville/src/main.tsx`.
+- **R3F geometry allocation:** Memoized dynamic geometries in `AgentActor.tsx` for status bubbles, name tags, spiky hair, and crown accessories, with regression tests around stable constructor calls.
+- **Hubreceiver error language:** Normalized the missing `sessionId` API error to English.
+- **Legacy URL parsing:** Centralized legacy request URL parsing with a localhost fallback for missing or malformed Host headers.
+- **Production build validation:** `npm run build` now runs both TypeScript and the Vite frontend production build.
+- **Widget portability:** `widget/build.sh` no longer depends on GNU `readlink -f`.
+- **Test hygiene:** `vitest.setup.ts` resets the global `localStorage` mock before each test.
+
+### Already Covered Or Rechecked
+
+- **Collector runtime coverage:** `collector/index.real.test.ts` now covers startup publish, watcher-triggered flush, interval-triggered retry behavior, and shutdown cleanup.
+- **Adapter fixture coverage:** The repo already has real fixture tests for the adapter registry and several providers, including `index.fixture.test.ts`, `gemini.fixture.test.ts`, `openclaw.fixture.test.ts`, and `vscode.real.test.ts`. The broad `claude.test.ts` still contains some inline helper tests and remains a cleanup candidate.
+- **Frontend component coverage:** React shell tests already covered boot, mode switching, settings, selection, and activity surfaces; this branch adds the top-level error boundary and AgentActor geometry tests.
+
+### Deferred
+
+- **Authentication and origin checks:** This is a real exposure risk, but it needs a product/runtime policy decision. Suggested follow-up: default local-address guard for legacy mode, bearer-token read/write protection for hubreceiver deployments, and explicit HTTP/WS origin allowlists for remote usage.
+- **State identity and dashboard refetch churn:** Stabilizing `agents` array identity and dashboard request dependencies should be handled as a separate performance branch.
+- **WorldScene per-frame complexity:** Optimize sprite/building lookup maps after profiling or adding scene-scale regression coverage.
+- **Agent stale-removal policy:** Needs behavior agreement because changing stale removal can affect visible session history.
+- **Adapter hardcoded scan windows:** Needs provider-specific follow-up for Codex and Copilot session-detail discovery.
+- **Snapshot structural validation:** Worth a focused hubreceiver contract-validation pass.
+- **ESLint React plugin and broader lint tightening:** Useful, but likely broad churn and should be a dedicated cleanup PR.
+- **Responsive sidebar/CSS polish, stable project color pruning, WorldText character memoization, and key collision cleanup:** Lower-risk UI quality follow-ups.
+
+### Verification Used
+
+Focused verification during implementation:
+
+```bash
+npm run test -- claudeville/server.test.ts
+npm run test -- shared/watch-utils.test.ts collector/index.real.test.ts
+npm run test -- claudeville/src/presentation/react/ErrorBoundary.test.tsx claudeville/src/presentation/react/ClaudeVilleApp.test.tsx
+npm run test -- claudeville/src/presentation/react/world/utils.test.ts claudeville/src/presentation/react/world/components/AgentActor.test.tsx
+npm run test -- collector/snapshot.test.ts collector/index.real.test.ts
+npm run test -- hubreceiver/routes.test.ts claudeville/server.test.ts
+npm run widget:build
+npm run build
+npm run typecheck
+npm run lint
+```

--- a/docs/deepseek-review.md
+++ b/docs/deepseek-review.md
@@ -161,7 +161,7 @@ Updated on 26 April 2026 by `codex/plan-deepseek-review-fixes`.
 - **WebSocket diagnostics and backpressure behavior:** Legacy WebSocket socket errors and initial-data failures are now logged. `ws` owns protocol parsing, buffering, ping/pong handling, and send callbacks instead of the server dropping sockets based on raw `write()` return values.
 - **Watcher lifecycle cleanup:** `shared/watch-utils.js` now returns watcher handles and an idempotent `close()` function. The collector and legacy server retain watcher/interval handles and clear them during shutdown.
 - **Collector interval cleanup:** `collector/index.ts` stores and clears its periodic publish interval during shutdown.
-- **Collector detail fetch concurrency:** `collector/snapshot.ts` fetches missing session details with `Promise.all` while preserving output order.
+- **Collector detail fetch concurrency:** `collector/snapshot.ts` fetches missing session details with `Promise.all` while preserving output order and isolating per-session detail lookup failures.
 - **React error boundary:** Added a top-level `ErrorBoundary` around `ClaudeVilleApp` in `claudeville/src/main.tsx`.
 - **R3F geometry allocation:** Memoized dynamic geometries in `AgentActor.tsx` for status bubbles, name tags, spiky hair, and crown accessories, with regression tests around stable constructor calls.
 - **Hubreceiver error language:** Normalized the missing `sessionId` API error to English.
@@ -172,7 +172,7 @@ Updated on 26 April 2026 by `codex/plan-deepseek-review-fixes`.
 
 ### Already Covered Or Rechecked
 
-- **Collector runtime coverage:** `collector/index.real.test.ts` now covers startup publish, watcher-triggered flush, interval-triggered retry behavior, and shutdown cleanup.
+- **Collector runtime coverage:** `collector/index.real.test.ts` now covers startup publish, watcher-triggered flush, interval-triggered retry behavior, shutdown cleanup, and interval callback removal after `clearInterval`.
 - **Adapter fixture coverage:** The repo already has real fixture tests for the adapter registry and several providers, including `index.fixture.test.ts`, `gemini.fixture.test.ts`, `openclaw.fixture.test.ts`, and `vscode.real.test.ts`. The broad `claude.test.ts` still contains some inline helper tests and remains a cleanup candidate.
 - **Frontend component coverage:** React shell tests already covered boot, mode switching, settings, selection, and activity surfaces; this branch adds the top-level error boundary and AgentActor geometry tests.
 

--- a/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
@@ -342,7 +342,7 @@ npm run lint
 
 Expected: all pass. If `npm run widget:build` cannot complete because macOS app packaging requires local-only tools, record the exact blocker in the final status.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add hubreceiver/routes.ts hubreceiver/*.test.ts package.json widget/build.sh claudeville/server.ts claudeville/server.test.ts
@@ -364,19 +364,19 @@ git commit -m "chore: address review cleanups"
 
 For each adapter with duplicate inline helpers, import the real adapter module and parse fixture files under a temporary directory. Assert normalized provider, session ID, project grouping, timestamps, token/cost fields, and detail extraction.
 
-- [ ] **Step 2: Add collector runtime coverage**
+- [x] **Step 2: Add collector runtime coverage**
 
 Extend `collector/index.real.test.ts` to exercise `main()`, `scheduleFlush()`, `publishSnapshot()`, watcher-triggered flush, interval-triggered flush, and `shutdown()`.
 
-- [ ] **Step 3: Add server error-path coverage**
+- [x] **Step 3: Add server error-path coverage**
 
 Add tests for `sendInitialData()` failure logging, socket error logging, malformed URL handling, and WebSocket close/ping behavior.
 
-- [ ] **Step 4: Add React smoke coverage**
+- [x] **Step 4: Add React smoke coverage**
 
 Keep this small: render `ClaudeVilleApp`, switch between world/dashboard modes, open/close settings, and assert no uncaught render errors. Reset `localStorageMock` in `vitest.setup.ts` before each test so component tests do not share state.
 
-- [ ] **Step 5: Verify**
+- [x] **Step 5: Verify**
 
 Run:
 
@@ -403,7 +403,7 @@ git commit -m "test: cover review risk areas"
 **Files:**
 - Modify: `docs/deepseek-review.md`
 
-- [ ] **Step 1: Add a status appendix**
+- [x] **Step 1: Add a status appendix**
 
 Append a section with three statuses:
 
@@ -411,7 +411,7 @@ Append a section with three statuses:
 - `Deferred`: larger work that needs its own issue, such as auth/origin policy if product behavior is not yet agreed.
 - `Rejected/Needs Recheck`: findings that proved stale or inaccurate after code inspection.
 
-- [ ] **Step 2: Include verification evidence**
+- [x] **Step 2: Include verification evidence**
 
 Record the final command set and result:
 
@@ -422,7 +422,7 @@ npm run test
 npm run build
 ```
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add docs/deepseek-review.md

--- a/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
@@ -51,7 +51,7 @@ Established libraries are allowed when advisable. For WebSocket work, explicitly
 - Potentially modify: `package.json`
 - Potentially modify: `package-lock.json`
 
-- [ ] **Step 1: Choose the transport implementation path**
+- [x] **Step 1: Choose the transport implementation path**
 
 Compare two approaches before editing production code:
 
@@ -60,14 +60,14 @@ Compare two approaches before editing production code:
 
 Default to the library if it materially reduces protocol correctness or security maintenance risk without forcing unrelated server rewrites. If adding a dependency, record why it was chosen and keep the integration narrow.
 
-- [ ] **Step 2: Write failing tests for fragmented and coalesced frames**
+- [x] **Step 2: Write failing tests for fragmented and coalesced frames**
 
 Add tests that connect to the legacy server's WebSocket endpoint, send a masked text frame split across two `socket.write()` calls, and assert the server replies to `{ "type": "ping" }` with a pong. Add a second test that sends two masked ping frames in one TCP write and expects two pong frames.
 
 Run: `npm run test -- claudeville/server.test.ts`
 Expected: the new tests fail because `handleWebSocketFrame` currently treats each `data` chunk as exactly one frame.
 
-- [ ] **Step 3: Implement the selected WebSocket fix**
+- [x] **Step 3: Implement the selected WebSocket fix**
 
 If patching the existing parser, replace the single-buffer parser with a small parser that stores `_claudevilleWsBuffer` and `_claudevilleWsContinuation` on the socket. The parser should:
 
@@ -80,11 +80,11 @@ If patching the existing parser, replace the single-buffer parser with a small p
 
 If adopting `ws`, keep the current HTTP server and route handlers, attach a `WebSocketServer` in `noServer` mode to the existing upgrade path, preserve existing `init`/`update` payloads, and remove only the custom frame parsing/sending code made obsolete by the library.
 
-- [ ] **Step 4: Keep diagnostics visible**
+- [x] **Step 4: Keep diagnostics visible**
 
 Change `socket.on('error')` to log the error message before removing the socket. Change `sendInitialData()` to log adapter/read failures instead of swallowing them.
 
-- [ ] **Step 5: Verify**
+- [x] **Step 5: Verify**
 
 Run:
 

--- a/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
@@ -251,7 +251,7 @@ npm run lint
 
 Expected: all pass.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add claudeville/src/presentation/react/world/components/AgentActor.tsx claudeville/src/presentation/react/world/components/AgentActor.test.tsx
@@ -266,18 +266,18 @@ git commit -m "fix: memoize agent actor geometries"
 - Modify: `collector/snapshot.ts`
 - Test: `collector/snapshot.test.ts`
 
-- [ ] **Step 1: Write a timing/order test**
+- [x] **Step 1: Write a timing/order test**
 
 Create a test with three sessions whose mocked detail fetches resolve out of order. Assert `buildCollectorSnapshot()` keeps the original session order while awaiting details in parallel.
 
 Run: `npm run test -- collector/snapshot.test.ts`
 Expected: fail if the current code awaits each detail fetch sequentially or lacks the observable seam.
 
-- [ ] **Step 2: Implement parallel fetch**
+- [x] **Step 2: Implement parallel fetch**
 
 Replace the one-by-one loop with `await Promise.all(sessions.map(async (session) => ...))`. Preserve the existing per-session fallback behavior so one detail failure does not fail the entire snapshot.
 
-- [ ] **Step 3: Verify**
+- [x] **Step 3: Verify**
 
 Run:
 

--- a/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
@@ -96,7 +96,7 @@ npm run lint
 
 Expected: all pass.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add claudeville/server.ts claudeville/server.test.ts package.json package-lock.json
@@ -114,14 +114,14 @@ git commit -m "fix: buffer legacy websocket frames"
 - Test: `shared/watch-utils.test.ts`
 - Test: `collector/index.real.test.ts`
 
-- [ ] **Step 1: Write failing cleanup tests**
+- [x] **Step 1: Write failing cleanup tests**
 
 Add tests that mock `fs.watch()` to return closeable watcher objects. Assert `createFileWatchers(...).close()` calls each watcher's `close()` exactly once and clears the pending debounce timer. In `collector/index.real.test.ts`, inject `clearInterval`, call `runtime.main()`, then `runtime.shutdown()`, and assert watcher cleanup plus interval cleanup.
 
 Run: `npm run test -- shared/watch-utils.test.ts collector/index.real.test.ts`
 Expected: fail because watcher handles and interval IDs are not retained.
 
-- [ ] **Step 2: Return structured watcher handles**
+- [x] **Step 2: Return structured watcher handles**
 
 Update `createFileWatchers()` to return:
 
@@ -138,13 +138,13 @@ Update `createFileWatchers()` to return:
 
 Keep the function JavaScript-compatible and update JSDoc so TypeScript callers understand the returned shape.
 
-- [ ] **Step 3: Store lifecycle handles**
+- [x] **Step 3: Store lifecycle handles**
 
 In `collector/index.ts`, widen `CollectorRuntimeDeps` with `clearInterval`, store the watcher handle returned by `startWatchers()`, store the interval ID from `setInterval()`, and clear both in `shutdown()` before `process.exit(0)`.
 
 In `claudeville/server.ts`, retain the legacy file watcher handle and polling interval ID so local shutdown hooks can close them later. If the server has no existing explicit shutdown export, keep this change minimal by preparing the handles and using them in the existing process-signal path if present.
 
-- [ ] **Step 4: Verify**
+- [x] **Step 4: Verify**
 
 Run:
 

--- a/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
@@ -389,7 +389,7 @@ npm run lint
 
 Expected: all pass.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add claudeville/adapters/*.test.ts collector/*.test.ts claudeville/server.test.ts claudeville/src/presentation/react/ClaudeVilleApp.test.tsx vitest.setup.ts

--- a/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
@@ -156,7 +156,7 @@ npm run lint
 
 Expected: all pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add shared/watch-utils.js shared/watch-utils.test.ts collector/index.ts collector/index.real.test.ts claudeville/server.ts
@@ -172,18 +172,18 @@ git commit -m "fix: clean up watchers and collector timers"
 - Modify: `claudeville/src/main.tsx`
 - Test: `claudeville/src/presentation/react/ErrorBoundary.test.tsx`
 
-- [ ] **Step 1: Write failing boundary test**
+- [x] **Step 1: Write failing boundary test**
 
 Create a test component that throws in render. Render it inside `ErrorBoundary` and assert the fallback includes a concise failure message and does not rethrow to the test runner.
 
 Run: `npm run test -- claudeville/src/presentation/react/ErrorBoundary.test.tsx`
 Expected: fail because the component does not exist.
 
-- [ ] **Step 2: Implement `ErrorBoundary`**
+- [x] **Step 2: Implement `ErrorBoundary`**
 
 Use a class component with `getDerivedStateFromError()` and `componentDidCatch()`. Log the error via `console.error('[React] render failed:', error)` and render a fallback using the existing `boot-error` classes so styling stays consistent.
 
-- [ ] **Step 3: Wrap the root**
+- [x] **Step 3: Wrap the root**
 
 Update `claudeville/src/main.tsx`:
 
@@ -195,7 +195,7 @@ createRoot(rootElement).render(
 );
 ```
 
-- [ ] **Step 4: Verify**
+- [x] **Step 4: Verify**
 
 Run:
 

--- a/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
@@ -288,7 +288,7 @@ npm run typecheck
 
 Expected: all pass.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add collector/snapshot.ts collector/snapshot.test.ts
@@ -306,15 +306,15 @@ git commit -m "perf: parallelize collector detail fetches"
 - Modify: `widget/build.sh`
 - Test: relevant existing route/build tests
 
-- [ ] **Step 1: Normalize hubreceiver error text**
+- [x] **Step 1: Normalize hubreceiver error text**
 
 Change the missing `sessionId` message from Korean to English, for example `sessionId is required`. Add or update the route test that asserts the response.
 
-- [ ] **Step 2: Harden malformed Host parsing**
+- [x] **Step 2: Harden malformed Host parsing**
 
 In `claudeville/server.ts`, wrap URL construction in a small helper that defaults the host to `localhost` when `req.headers.host` is missing or malformed. Add a test for a missing host header if the server test harness can construct it directly.
 
-- [ ] **Step 3: Make widget path resolution portable**
+- [x] **Step 3: Make widget path resolution portable**
 
 Replace `readlink -f` in `widget/build.sh` with a macOS-compatible helper:
 
@@ -325,11 +325,11 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 
 Keep the script behavior otherwise unchanged.
 
-- [ ] **Step 4: Decide and verify production build coverage**
+- [x] **Step 4: Decide and verify production build coverage**
 
 If the team wants `npm run build` to validate the browser bundle, change it to `npm run typecheck && npm run build:frontend`. If that makes regular local checks too slow, leave `build` alone and document `npm run build:frontend` as a CI-required command in the review status appendix.
 
-- [ ] **Step 5: Verify**
+- [x] **Step 5: Verify**
 
 Run:
 

--- a/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
@@ -206,7 +206,7 @@ npm run typecheck
 
 Expected: all pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add claudeville/src/main.tsx claudeville/src/presentation/react/ErrorBoundary.tsx claudeville/src/presentation/react/ErrorBoundary.test.tsx
@@ -221,14 +221,14 @@ git commit -m "fix: add react error boundary"
 - Modify: `claudeville/src/presentation/react/world/components/AgentActor.tsx`
 - Test: `claudeville/src/presentation/react/world/components/AgentActor.test.tsx`
 
-- [ ] **Step 1: Add a regression test or measurable utility seam**
+- [x] **Step 1: Add a regression test or measurable utility seam**
 
 If direct component testing is practical, mock `createRoundedRectGeometry` and `createPolygonGeometry`, render `Bubble`, `NameTag`, `Hair`, and `Accessory` through `AgentActor`, rerender with identical props, and assert stable constructor call counts. If those internals are not exportable, extract tiny local memoized subcomponents first, then test the exported `AgentActor` behavior with stable props.
 
 Run: `npm run test -- claudeville/src/presentation/react/world/components/AgentActor.test.tsx`
 Expected: fail because dynamic geometry constructors run during every render.
 
-- [ ] **Step 2: Memoize dynamic geometries**
+- [x] **Step 2: Memoize dynamic geometries**
 
 Import `useMemo` and `useEffect`. Use `useMemo()` for:
 
@@ -239,7 +239,7 @@ Import `useMemo` and `useEffect`. Use `useMemo()` for:
 
 For geometries passed through the `geometry` prop, dispose them in a cleanup effect only if React Three Fiber will not already dispose them. Prefer the repo's existing R3F pattern in `TerrainLayer.tsx` and `BuildingActor.tsx`.
 
-- [ ] **Step 3: Verify**
+- [x] **Step 3: Verify**
 
 Run:
 

--- a/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-26-deepseek-review-fixes.md
@@ -1,0 +1,460 @@
+# DeepSeek Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve the highest-risk findings in `docs/deepseek-review.md` with small, verified changes that preserve ClaudeVille's legacy and split-stack runtime contracts.
+
+**Architecture:** Treat the legacy server, split-stack collector/hubreceiver, and React/R3F frontend as separate phases. Keep transport lifecycle changes in shared/server modules, keep GPU resource fixes inside R3F components, and add tests before each behavioral change where the current test harness can express the failure.
+
+**Tech Stack:** TypeScript, React 19, React Three Fiber, Three.js, Node `http`/`net`, Vitest, Testing Library, Vite.
+
+---
+
+## Scope And Ordering
+
+This review is too broad for one change. Implement in this order so each step is testable and revertible:
+
+1. WebSocket frame buffering and diagnostics in the legacy server.
+2. Watcher and collector lifecycle cleanup.
+3. React/R3F crash and GPU allocation fixes.
+4. Low-risk API/config/build cleanups.
+5. Coverage expansion for adapters, collector runtime, server error paths, and React smoke behavior.
+
+Established libraries are allowed when advisable. For WebSocket work, explicitly compare repairing the hand-rolled parser with adopting a maintained library such as `ws`; choose the lower-risk option and document the tradeoff in the implementation commit or review appendix.
+
+## Files To Modify
+
+- `claudeville/server.ts`: buffer partial WebSocket frames per socket, process multiple frames per TCP chunk, log socket/send/init failures, retain watcher and interval handles for shutdown.
+- `claudeville/server.test.ts`: add focused tests for fragmented/multiple WebSocket frames, silent init failure logging, malformed host handling, and broadcast backpressure behavior where practical.
+- `shared/watch-utils.js`: return watcher handles plus a `close()` function, clear the debounce timer on close, and log individual watch failures without aborting.
+- `shared/watch-utils.test.ts`: test file and directory watch cleanup behavior with mocked `fs.watch`.
+- `collector/index.ts`: store watcher cleanup and interval ID, clear both in `shutdown()`, and expose lifecycle state for tests.
+- `collector/index.real.test.ts`: assert `shutdown()` closes watchers, clears the interval, and does not leave publisher timers running.
+- `claudeville/src/presentation/react/ErrorBoundary.tsx`: create a top-level React error boundary with a compact fallback UI.
+- `claudeville/src/main.tsx`: wrap `ClaudeVilleApp` in `ErrorBoundary`.
+- `claudeville/src/presentation/react/ErrorBoundary.test.tsx`: assert child render failures show the fallback without unmounting the whole root.
+- `claudeville/src/presentation/react/world/components/AgentActor.tsx`: memoize rounded rectangle and polygon geometries created from props; dispose memoized geometries on unmount if React Three Fiber does not own them.
+- `claudeville/src/presentation/react/world/components/AgentActor.test.tsx`: add a small component-level test or utility-level assertion that dynamic geometry constructors are not called again when inputs are stable.
+- `collector/snapshot.ts`: parallelize session detail fetches with `Promise.all` while preserving ordering and error handling.
+- `hubreceiver/routes.ts`: normalize the Korean missing-session error string to English and add/adjust a route test.
+- `package.json`: decide whether `build` should run `npm run build:frontend` after `typecheck`; if changed, verify the production build.
+- `widget/build.sh`: replace GNU-only `readlink -f` with a macOS-compatible path resolution using `cd`/`pwd -P` or `realpath` with fallback.
+- `docs/deepseek-review.md`: after fixes land, add an appendix or status table marking which findings were fixed, deferred, or intentionally out of scope.
+
+---
+
+## Task 1: Legacy WebSocket Frame Buffering Or Library Adoption
+
+**Files:**
+- Modify: `claudeville/server.ts`
+- Test: `claudeville/server.test.ts`
+- Potentially modify: `package.json`
+- Potentially modify: `package-lock.json`
+
+- [ ] **Step 1: Choose the transport implementation path**
+
+Compare two approaches before editing production code:
+
+- Patch the existing parser in `claudeville/server.ts`.
+- Replace the legacy server's hand-rolled WebSocket upgrade/frame handling with an established library such as `ws`.
+
+Default to the library if it materially reduces protocol correctness or security maintenance risk without forcing unrelated server rewrites. If adding a dependency, record why it was chosen and keep the integration narrow.
+
+- [ ] **Step 2: Write failing tests for fragmented and coalesced frames**
+
+Add tests that connect to the legacy server's WebSocket endpoint, send a masked text frame split across two `socket.write()` calls, and assert the server replies to `{ "type": "ping" }` with a pong. Add a second test that sends two masked ping frames in one TCP write and expects two pong frames.
+
+Run: `npm run test -- claudeville/server.test.ts`
+Expected: the new tests fail because `handleWebSocketFrame` currently treats each `data` chunk as exactly one frame.
+
+- [ ] **Step 3: Implement the selected WebSocket fix**
+
+If patching the existing parser, replace the single-buffer parser with a small parser that stores `_claudevilleWsBuffer` and `_claudevilleWsContinuation` on the socket. The parser should:
+
+- append each TCP chunk to the saved buffer;
+- parse zero or more complete frames;
+- leave incomplete bytes buffered;
+- enforce the existing 100 MB payload cap;
+- handle masked text, close, ping, pong, and continuation frames;
+- report unsupported opcodes through `reportWebSocketFrameIssue()`.
+
+If adopting `ws`, keep the current HTTP server and route handlers, attach a `WebSocketServer` in `noServer` mode to the existing upgrade path, preserve existing `init`/`update` payloads, and remove only the custom frame parsing/sending code made obsolete by the library.
+
+- [ ] **Step 4: Keep diagnostics visible**
+
+Change `socket.on('error')` to log the error message before removing the socket. Change `sendInitialData()` to log adapter/read failures instead of swallowing them.
+
+- [ ] **Step 5: Verify**
+
+Run:
+
+```bash
+npm run test -- claudeville/server.test.ts
+npm run typecheck
+npm run lint
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add claudeville/server.ts claudeville/server.test.ts package.json package-lock.json
+git commit -m "fix: buffer legacy websocket frames"
+```
+
+---
+
+## Task 2: Watcher And Collector Shutdown
+
+**Files:**
+- Modify: `shared/watch-utils.js`
+- Modify: `collector/index.ts`
+- Modify: `claudeville/server.ts`
+- Test: `shared/watch-utils.test.ts`
+- Test: `collector/index.real.test.ts`
+
+- [ ] **Step 1: Write failing cleanup tests**
+
+Add tests that mock `fs.watch()` to return closeable watcher objects. Assert `createFileWatchers(...).close()` calls each watcher's `close()` exactly once and clears the pending debounce timer. In `collector/index.real.test.ts`, inject `clearInterval`, call `runtime.main()`, then `runtime.shutdown()`, and assert watcher cleanup plus interval cleanup.
+
+Run: `npm run test -- shared/watch-utils.test.ts collector/index.real.test.ts`
+Expected: fail because watcher handles and interval IDs are not retained.
+
+- [ ] **Step 2: Return structured watcher handles**
+
+Update `createFileWatchers()` to return:
+
+```ts
+{
+  watchCount,
+  watchers,
+  close() {
+    if (timer) clearTimeout(timer);
+    for (const watcher of watchers) watcher.close();
+  },
+}
+```
+
+Keep the function JavaScript-compatible and update JSDoc so TypeScript callers understand the returned shape.
+
+- [ ] **Step 3: Store lifecycle handles**
+
+In `collector/index.ts`, widen `CollectorRuntimeDeps` with `clearInterval`, store the watcher handle returned by `startWatchers()`, store the interval ID from `setInterval()`, and clear both in `shutdown()` before `process.exit(0)`.
+
+In `claudeville/server.ts`, retain the legacy file watcher handle and polling interval ID so local shutdown hooks can close them later. If the server has no existing explicit shutdown export, keep this change minimal by preparing the handles and using them in the existing process-signal path if present.
+
+- [ ] **Step 4: Verify**
+
+Run:
+
+```bash
+npm run test -- shared/watch-utils.test.ts collector/index.real.test.ts
+npm run typecheck
+npm run lint
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/watch-utils.js shared/watch-utils.test.ts collector/index.ts collector/index.real.test.ts claudeville/server.ts
+git commit -m "fix: clean up watchers and collector timers"
+```
+
+---
+
+## Task 3: React Error Boundary
+
+**Files:**
+- Create: `claudeville/src/presentation/react/ErrorBoundary.tsx`
+- Modify: `claudeville/src/main.tsx`
+- Test: `claudeville/src/presentation/react/ErrorBoundary.test.tsx`
+
+- [ ] **Step 1: Write failing boundary test**
+
+Create a test component that throws in render. Render it inside `ErrorBoundary` and assert the fallback includes a concise failure message and does not rethrow to the test runner.
+
+Run: `npm run test -- claudeville/src/presentation/react/ErrorBoundary.test.tsx`
+Expected: fail because the component does not exist.
+
+- [ ] **Step 2: Implement `ErrorBoundary`**
+
+Use a class component with `getDerivedStateFromError()` and `componentDidCatch()`. Log the error via `console.error('[React] render failed:', error)` and render a fallback using the existing `boot-error` classes so styling stays consistent.
+
+- [ ] **Step 3: Wrap the root**
+
+Update `claudeville/src/main.tsx`:
+
+```tsx
+createRoot(rootElement).render(
+  <ErrorBoundary>
+    <ClaudeVilleApp />
+  </ErrorBoundary>,
+);
+```
+
+- [ ] **Step 4: Verify**
+
+Run:
+
+```bash
+npm run test -- claudeville/src/presentation/react/ErrorBoundary.test.tsx claudeville/src/presentation/react/ClaudeVilleApp.test.tsx
+npm run typecheck
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add claudeville/src/main.tsx claudeville/src/presentation/react/ErrorBoundary.tsx claudeville/src/presentation/react/ErrorBoundary.test.tsx
+git commit -m "fix: add react error boundary"
+```
+
+---
+
+## Task 4: R3F Geometry Memoization
+
+**Files:**
+- Modify: `claudeville/src/presentation/react/world/components/AgentActor.tsx`
+- Test: `claudeville/src/presentation/react/world/components/AgentActor.test.tsx`
+
+- [ ] **Step 1: Add a regression test or measurable utility seam**
+
+If direct component testing is practical, mock `createRoundedRectGeometry` and `createPolygonGeometry`, render `Bubble`, `NameTag`, `Hair`, and `Accessory` through `AgentActor`, rerender with identical props, and assert stable constructor call counts. If those internals are not exportable, extract tiny local memoized subcomponents first, then test the exported `AgentActor` behavior with stable props.
+
+Run: `npm run test -- claudeville/src/presentation/react/world/components/AgentActor.test.tsx`
+Expected: fail because dynamic geometry constructors run during every render.
+
+- [ ] **Step 2: Memoize dynamic geometries**
+
+Import `useMemo` and `useEffect`. Use `useMemo()` for:
+
+- `Bubble` rounded rectangle geometry keyed by `width` and `bubbleConfig.statusBubbleH`;
+- `NameTag` rounded rectangle geometry keyed by `width`;
+- spiky hair polygon geometry;
+- crown accessory polygon geometry.
+
+For geometries passed through the `geometry` prop, dispose them in a cleanup effect only if React Three Fiber will not already dispose them. Prefer the repo's existing R3F pattern in `TerrainLayer.tsx` and `BuildingActor.tsx`.
+
+- [ ] **Step 3: Verify**
+
+Run:
+
+```bash
+npm run test -- claudeville/src/presentation/react/world/utils.test.ts claudeville/src/presentation/react/world/components/AgentActor.test.tsx
+npm run typecheck
+npm run lint
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add claudeville/src/presentation/react/world/components/AgentActor.tsx claudeville/src/presentation/react/world/components/AgentActor.test.tsx
+git commit -m "fix: memoize agent actor geometries"
+```
+
+---
+
+## Task 5: Collector Snapshot Parallel Detail Fetch
+
+**Files:**
+- Modify: `collector/snapshot.ts`
+- Test: `collector/snapshot.test.ts`
+
+- [ ] **Step 1: Write a timing/order test**
+
+Create a test with three sessions whose mocked detail fetches resolve out of order. Assert `buildCollectorSnapshot()` keeps the original session order while awaiting details in parallel.
+
+Run: `npm run test -- collector/snapshot.test.ts`
+Expected: fail if the current code awaits each detail fetch sequentially or lacks the observable seam.
+
+- [ ] **Step 2: Implement parallel fetch**
+
+Replace the one-by-one loop with `await Promise.all(sessions.map(async (session) => ...))`. Preserve the existing per-session fallback behavior so one detail failure does not fail the entire snapshot.
+
+- [ ] **Step 3: Verify**
+
+Run:
+
+```bash
+npm run test -- collector/snapshot.test.ts collector/index.real.test.ts
+npm run typecheck
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add collector/snapshot.ts collector/snapshot.test.ts
+git commit -m "perf: parallelize collector detail fetches"
+```
+
+---
+
+## Task 6: API, Build, And Portability Cleanups
+
+**Files:**
+- Modify: `hubreceiver/routes.ts`
+- Modify: `hubreceiver/*.test.ts`
+- Modify: `package.json`
+- Modify: `widget/build.sh`
+- Test: relevant existing route/build tests
+
+- [ ] **Step 1: Normalize hubreceiver error text**
+
+Change the missing `sessionId` message from Korean to English, for example `sessionId is required`. Add or update the route test that asserts the response.
+
+- [ ] **Step 2: Harden malformed Host parsing**
+
+In `claudeville/server.ts`, wrap URL construction in a small helper that defaults the host to `localhost` when `req.headers.host` is missing or malformed. Add a test for a missing host header if the server test harness can construct it directly.
+
+- [ ] **Step 3: Make widget path resolution portable**
+
+Replace `readlink -f` in `widget/build.sh` with a macOS-compatible helper:
+
+```bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+```
+
+Keep the script behavior otherwise unchanged.
+
+- [ ] **Step 4: Decide and verify production build coverage**
+
+If the team wants `npm run build` to validate the browser bundle, change it to `npm run typecheck && npm run build:frontend`. If that makes regular local checks too slow, leave `build` alone and document `npm run build:frontend` as a CI-required command in the review status appendix.
+
+- [ ] **Step 5: Verify**
+
+Run:
+
+```bash
+npm run test -- hubreceiver
+npm run widget:build
+npm run build
+npm run lint
+```
+
+Expected: all pass. If `npm run widget:build` cannot complete because macOS app packaging requires local-only tools, record the exact blocker in the final status.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hubreceiver/routes.ts hubreceiver/*.test.ts package.json widget/build.sh claudeville/server.ts claudeville/server.test.ts
+git commit -m "chore: address review cleanups"
+```
+
+---
+
+## Task 7: Coverage Expansion
+
+**Files:**
+- Modify: `claudeville/adapters/*.test.ts`
+- Modify: `collector/collector.test.ts` or `collector/index.real.test.ts`
+- Modify: `claudeville/server.test.ts`
+- Modify: `claudeville/src/presentation/react/ClaudeVilleApp.test.tsx`
+- Modify: `vitest.setup.ts`
+
+- [ ] **Step 1: Replace adapter helper-duplicate tests with real fixtures**
+
+For each adapter with duplicate inline helpers, import the real adapter module and parse fixture files under a temporary directory. Assert normalized provider, session ID, project grouping, timestamps, token/cost fields, and detail extraction.
+
+- [ ] **Step 2: Add collector runtime coverage**
+
+Extend `collector/index.real.test.ts` to exercise `main()`, `scheduleFlush()`, `publishSnapshot()`, watcher-triggered flush, interval-triggered flush, and `shutdown()`.
+
+- [ ] **Step 3: Add server error-path coverage**
+
+Add tests for `sendInitialData()` failure logging, socket error logging, malformed URL handling, and WebSocket close/ping behavior.
+
+- [ ] **Step 4: Add React smoke coverage**
+
+Keep this small: render `ClaudeVilleApp`, switch between world/dashboard modes, open/close settings, and assert no uncaught render errors. Reset `localStorageMock` in `vitest.setup.ts` before each test so component tests do not share state.
+
+- [ ] **Step 5: Verify**
+
+Run:
+
+```bash
+npm run test
+npm run test:coverage
+npm run typecheck
+npm run lint
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add claudeville/adapters/*.test.ts collector/*.test.ts claudeville/server.test.ts claudeville/src/presentation/react/ClaudeVilleApp.test.tsx vitest.setup.ts
+git commit -m "test: cover review risk areas"
+```
+
+---
+
+## Task 8: Review Status Appendix
+
+**Files:**
+- Modify: `docs/deepseek-review.md`
+
+- [ ] **Step 1: Add a status appendix**
+
+Append a section with three statuses:
+
+- `Fixed`: items completed by this branch.
+- `Deferred`: larger work that needs its own issue, such as auth/origin policy if product behavior is not yet agreed.
+- `Rejected/Needs Recheck`: findings that proved stale or inaccurate after code inspection.
+
+- [ ] **Step 2: Include verification evidence**
+
+Record the final command set and result:
+
+```bash
+npm run typecheck
+npm run lint
+npm run test
+npm run build
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/deepseek-review.md
+git commit -m "docs: record deepseek review fix status"
+```
+
+---
+
+## Deferred Design Decisions
+
+- **Auth and origin checks:** The review correctly flags network exposure risk, but the remediation needs a product decision. Candidate policy: default local-address guard for legacy mode, token auth for split-stack hubreceiver writes and reads, and explicit `HUB_CORS_ORIGINS`/WS origin allowlist for remote deployments.
+- **React state identity optimization:** Stabilizing `agents` arrays and derived dashboard requests is useful, but it should be a separate performance branch after correctness and lifecycle fixes land.
+- **WorldScene O(NxM) per-frame work:** Worth profiling after the geometry leak is fixed; optimize with ID maps only when a test or profile shows the current scene size needs it.
+- **ESLint React plugin:** Reasonable, but adding rules can create broad churn. Do it after the behavioral review fixes are merged.
+
+## Final Verification
+
+Before opening a PR, run:
+
+```bash
+npm run typecheck
+npm run lint
+npm run test
+npm run build
+```
+
+If this branch implements WebSocket or live collector changes, also run the split stack manually:
+
+```bash
+npm run dev:hubreceiver
+npm run dev:collector
+npm run dev:frontend
+```
+
+Then verify the browser UI receives initial state and live updates through the hubreceiver WebSocket.

--- a/hubreceiver/routes.test.ts
+++ b/hubreceiver/routes.test.ts
@@ -222,7 +222,7 @@ describe('hubreceiver routes', () => {
     const missingRes = makeResponse();
     handler(missingReq, missingRes);
     expect(missingRes.writeHead).toHaveBeenCalledWith(400, expect.any(Object));
-    expect(missingRes.end).toHaveBeenCalledWith(JSON.stringify({ error: 'sessionId 필수' }));
+    expect(missingRes.end).toHaveBeenCalledWith(JSON.stringify({ error: 'sessionId is required' }));
 
     const unknownReq = makeRequest('GET', '/api/does-not-exist', { host: 'localhost' });
     const unknownRes = makeResponse();

--- a/hubreceiver/routes.ts
+++ b/hubreceiver/routes.ts
@@ -77,7 +77,7 @@ export function createHubreceiverRequestHandler(deps: HubreceiverDeps) {
       const sessionId = url.searchParams.get('sessionId');
       const provider = url.searchParams.get('provider') || 'claude';
       if (!sessionId) {
-        sendError(res, 400, 'sessionId 필수');
+        sendError(res, 400, 'sessionId is required');
         return;
       }
       sendJson(res, 200, deps.getSessionDetail(sessionId, provider));

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.6.0",
+        "@types/ws": "^8.18.1",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "three": "^0.183.2",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.2",
+        "ws": "^8.20.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -2126,7 +2128,6 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -2204,7 +2205,6 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -5607,7 +5607,6 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -5975,7 +5974,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -46,9 +46,11 @@
   "dependencies": {
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.0",
+    "@types/ws": "^8.18.1",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "three": "^0.183.2",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "ws": "^8.20.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
-    "build": "npm run typecheck",
+    "build": "npm run typecheck && npm run build:frontend",
     "test": "vitest run",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "test:coverage": "vitest run --coverage",

--- a/shared/watch-utils.js
+++ b/shared/watch-utils.js
@@ -8,36 +8,61 @@ import fs from 'fs';
  * @param {Array<{path: string, type: 'file'|'directory', filter?: string, recursive?: boolean}>} watchPaths
  * @param {Function} onChange  - Called with no arguments when a watched path changes
  * @param {number} [debounceMs=200]  - Debounce delay
- * @returns {{ watchCount: number }}
+ * @returns {{ watchCount: number, watchers: fs.FSWatcher[], close: () => void }}
  */
 export function createFileWatchers(watchPaths, onChange, debounceMs = 200) {
   let watchCount = 0;
   let timer = null;
+  let closed = false;
+  const watchers = [];
+
+  function scheduleChange() {
+    if (closed) return;
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      if (!closed) onChange();
+    }, debounceMs);
+  }
 
   for (const wp of watchPaths) {
     try {
       if (wp.type === 'file') {
         if (!fs.existsSync(wp.path)) continue;
-        fs.watch(wp.path, (eventType) => {
+        const watcher = fs.watch(wp.path, (eventType) => {
           if (eventType === 'change') {
-            if (timer) clearTimeout(timer);
-            timer = setTimeout(onChange, debounceMs);
+            scheduleChange();
           }
         });
+        watchers.push(watcher);
         watchCount++;
       } else if (wp.type === 'directory') {
         if (!fs.existsSync(wp.path)) continue;
-        fs.watch(wp.path, { recursive: wp.recursive || false }, (_eventType, filename) => {
+        const watcher = fs.watch(wp.path, { recursive: wp.recursive || false }, (_eventType, filename) => {
           if (wp.filter && filename && !filename.endsWith(wp.filter)) return;
-          if (timer) clearTimeout(timer);
-          timer = setTimeout(onChange, debounceMs);
+          scheduleChange();
         });
+        watchers.push(watcher);
         watchCount++;
       }
-    } catch {
-      // ignore individual watch failures
+    } catch (err) {
+      console.warn(`[watch-utils] failed to watch ${wp.path}: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
-  return { watchCount };
+  return {
+    watchCount,
+    watchers,
+    close() {
+      if (closed) return;
+      closed = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      for (const watcher of watchers) {
+        watcher.close();
+      }
+    },
+  };
 }

--- a/shared/watch-utils.test.ts
+++ b/shared/watch-utils.test.ts
@@ -1,0 +1,56 @@
+import fs from 'fs';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createFileWatchers } from './watch-utils.js';
+
+describe('createFileWatchers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns close handles for watched files and directories', () => {
+    const closeFile = vi.fn();
+    const closeDirectory = vi.fn();
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const watchSpy = vi.spyOn(fs, 'watch')
+      .mockReturnValueOnce({ close: closeFile } as fs.FSWatcher)
+      .mockReturnValueOnce({ close: closeDirectory } as fs.FSWatcher);
+
+    const result = createFileWatchers([
+      { path: '/tmp/session.jsonl', type: 'file' },
+      { path: '/tmp/sessions', type: 'directory', filter: '.jsonl', recursive: true },
+    ], vi.fn());
+
+    expect(result.watchCount).toBe(2);
+    expect(result.watchers).toHaveLength(2);
+    expect(watchSpy).toHaveBeenCalledTimes(2);
+
+    result.close();
+    result.close();
+
+    expect(closeFile).toHaveBeenCalledTimes(1);
+    expect(closeDirectory).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears a pending debounce timer when closed', () => {
+    vi.useFakeTimers();
+    const close = vi.fn();
+    const onChange = vi.fn();
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs, 'watch').mockImplementation((_path, listener) => {
+      if (typeof listener === 'function') {
+        listener('change', 'session.jsonl');
+      }
+      return { close } as fs.FSWatcher;
+    });
+
+    const result = createFileWatchers([{ path: '/tmp/session.jsonl', type: 'file' }], onChange, 50);
+    result.close();
+    vi.advanceTimersByTime(50);
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -3,7 +3,7 @@
  * Sets up the window mocks needed by browser-dependent code.
  */
 import '@testing-library/jest-dom/vitest';
-import { vi } from 'vitest';
+import { beforeEach, vi } from 'vitest';
 
 // Minimal localStorage mock (Map-backed, survives per-test isolation)
 const localStorageMock = (() => {
@@ -22,6 +22,14 @@ Object.defineProperty(globalThis, 'localStorage', {
   value: localStorageMock,
   writable: true,
   configurable: true,
+});
+
+beforeEach(() => {
+  localStorageMock.clear();
+  localStorageMock.getItem.mockClear();
+  localStorageMock.setItem.mockClear();
+  localStorageMock.removeItem.mockClear();
+  localStorageMock.clear.mockClear();
 });
 
 const runtimeWindow = (globalThis.window ?? ({} as Window & typeof globalThis)) as Window & typeof globalThis & {

--- a/widget/build.sh
+++ b/widget/build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
 
-cd "$(dirname "$0")"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+cd "$SCRIPT_DIR"
 
 echo "ClaudeVille Widget 빌드 시작..."
 
@@ -21,9 +22,14 @@ cp Info.plist ClaudeVilleWidget.app/Contents/
 cp Resources/* ClaudeVilleWidget.app/Contents/Resources/
 
 # 프로젝트 경로 + node 경로 기록 (서버 자동 시작용)
-PROJECT_ROOT="$(cd .. && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 echo "$PROJECT_ROOT" > ClaudeVilleWidget.app/Contents/Resources/project_path
-NODE_PATH="$(readlink -f "$(which node)" 2>/dev/null || realpath "$(which node)" 2>/dev/null || which node)"
+NODE_BIN="$(which node)"
+if NODE_PATH="$(realpath "$NODE_BIN" 2>/dev/null)"; then
+  :
+else
+  NODE_PATH="$(cd "$(dirname "$NODE_BIN")" && printf '%s/%s\n' "$(pwd -P)" "$(basename "$NODE_BIN")")"
+fi
 echo "$NODE_PATH" > ClaudeVilleWidget.app/Contents/Resources/node_path
 echo "  프로젝트: $PROJECT_ROOT"
 echo "  Node: $NODE_PATH"


### PR DESCRIPTION
## Summary

Implements the high-risk, reviewable portions of `docs/deepseek-review.md` on the fork branch. The legacy server now uses the maintained `ws` package for WebSocket protocol handling, with raw TCP regression tests for fragmented and coalesced frames. Watcher lifecycle cleanup is now explicit in shared watcher utilities, the collector, and the legacy server.

The branch also adds a top-level React error boundary, memoizes dynamic AgentActor geometries, parallelizes collector detail fetches, normalizes the hubreceiver missing-session error, hardens legacy URL parsing, makes widget path resolution portable, expands targeted tests, and records fixed/deferred status back into the review doc and plan.

## Validation

- `npm run test`
- `npm run lint`
- `npm run build`
- `npm run widget:build`

Note: `npm run build` emits the existing Vite large chunk warning, but exits successfully.