### PR TITLE
[codex] add OpenCode and Hermes adapters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,18 @@ CLAUDEVILLE_NAME_MODE_CODEX=autodetected
 CLAUDEVILLE_NAME_MODE_GEMINI=autodetected
 CLAUDEVILLE_NAME_MODE_OPENCLAW=autodetected
 CLAUDEVILLE_NAME_MODE_COPILOT=autodetected
+CLAUDEVILLE_NAME_MODE_OPENCODE=autodetected
+CLAUDEVILLE_NAME_MODE_HERMES=autodetected
+
+###############################################################################
+# Provider adapter data directories
+###############################################################################
+
+# Optional override for OpenCode data. Defaults to ~/.local/share/opencode.
+OPENCODE_DATA_DIR=/Users/me/.local/share/opencode
+
+# Optional override for Hermes Agent data. Defaults to ~/.hermes.
+HERMES_DIR=/Users/me/.hermes
 
 # Comma-separated pool for generated agent/team names.
 CLAUDEVILLE_AGENT_NAME_POOL=Atlas,Nova,Cipher,Pixel,Spark,Bolt,Echo,Flux,Helix,Onyx

--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,7 @@ CLAUDEVILLE_NAME_MODE_CODEX=autodetected
 CLAUDEVILLE_NAME_MODE_GEMINI=autodetected
 CLAUDEVILLE_NAME_MODE_OPENCLAW=autodetected
 CLAUDEVILLE_NAME_MODE_COPILOT=autodetected
+CLAUDEVILLE_NAME_MODE_PI=autodetected
 CLAUDEVILLE_NAME_MODE_OPENCODE=autodetected
 CLAUDEVILLE_NAME_MODE_HERMES=autodetected
 
@@ -79,10 +80,10 @@ CLAUDEVILLE_NAME_MODE_HERMES=autodetected
 ###############################################################################
 
 # Optional override for OpenCode data. Defaults to ~/.local/share/opencode.
-OPENCODE_DATA_DIR=/Users/me/.local/share/opencode
+#OPENCODE_DATA_DIR=/Users/me/.local/share/opencode
 
 # Optional override for Hermes Agent data. Defaults to ~/.hermes.
-HERMES_DIR=/Users/me/.hermes
+#HERMES_DIR=/Users/me/.hermes
 
 # Comma-separated pool for generated agent/team names.
 CLAUDEVILLE_AGENT_NAME_POOL=Atlas,Nova,Cipher,Pixel,Spark,Bolt,Echo,Flux,Helix,Onyx

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Each CLI stores session logs locally. ClaudeVille can run as a legacy all-in-one
 | OpenClaw | `~/.openclaw/` | 🟠 Orange |
 | GitHub Copilot CLI | `~/.copilot/` | 🔵 Cyan |
 | VS Code / VS Code Insiders Copilot Chat | `~/Library/Application Support/Code*/User/workspaceStorage/.../GitHub.copilot-chat/debug-logs/.../main.jsonl` | 🩵 Light Blue |
+| Pi Coding Agent | `~/.pi/agent/sessions/` | 🟡 Yellow |
+| OpenCode | `~/.opencode/` | 🔴 Red |
+| Hermes | `~/.hermes/` | 🟢 Green |
 
 > The VS Code / Insiders adapter uses provider key `vscode` (shared for stable UI grouping). Session IDs are namespaced as `vscode:<channel>:<workspaceId>:<sessionId>`.
 
@@ -58,7 +61,7 @@ Each CLI stores session logs locally. ClaudeVille can run as a legacy all-in-one
 
 - **World Mode** — Isometric pixel village where agents roam as characters with unique appearances
 - **Dashboard Mode** — Real-time agent cards showing tool usage, messages, and activity
-- **Multi-Provider** — Claude Code + Codex CLI + Gemini CLI + OpenClaw + Copilot CLI + VS Code Copilot Chat logs
+- **Multi-Provider** — Claude Code + Codex CLI + Gemini CLI + OpenClaw + Copilot CLI + VS Code Copilot Chat + Pi + OpenCode + Hermes
 - **Live Detection** — WebSocket + file watcher for instant session updates
 - **Agent Team & Swarm** — Auto-detects Claude Code teams, swarms, and sub-agents
 - **Project Grouping** — Agents grouped by project with color-coded sections
@@ -129,6 +132,9 @@ CLAUDEVILLE_NAME_MODE_CODEX=autodetected
 CLAUDEVILLE_NAME_MODE_GEMINI=autodetected
 CLAUDEVILLE_NAME_MODE_OPENCLAW=autodetected
 CLAUDEVILLE_NAME_MODE_COPILOT=autodetected
+CLAUDEVILLE_NAME_MODE_PI=autodetected
+CLAUDEVILLE_NAME_MODE_OPENCODE=autodetected
+CLAUDEVILLE_NAME_MODE_HERMES=autodetected
 
 # Separate pools for agent/team names and session names
 CLAUDEVILLE_AGENT_NAME_POOL=Atlas,Nova,Cipher,Pixel,Spark,Bolt,Echo,Flux,Helix,Onyx
@@ -215,7 +221,10 @@ claude-ville/
 │   │   ├── gemini.js          #   Gemini CLI adapter
 │   │   ├── copilot.js         #   Copilot CLI adapter
 │   │   ├── openclaw.js        #   OpenClaw adapter
-│   │   └── vscode.js          #   VS Code / Insiders adapter
+│   │   ├── vscode.js          #   VS Code / Insiders adapter
+│   │   ├── pi.js              #   Pi Coding Agent adapter
+│   │   ├── opencode.js        #   OpenCode adapter
+│   │   └── hermes.js          #   Hermes adapter
 │   ├── services/              #   Backend services
 │   │   └── usageQuota.js      #   Account & usage data
 │   ├── css/                   #   Stylesheets

--- a/claudeville/adapters/adapter-registry.test.ts
+++ b/claudeville/adapters/adapter-registry.test.ts
@@ -15,8 +15,12 @@ describe('adapter registry logic', () => {
       expect(estimateCost('claude-haiku-4-5', { input: 1_000_000, output: 0 })).toBeCloseTo(0.8);
     });
 
-    it('falls back to Sonnet for unknown models', () => {
-      expect(estimateCost('gpt-4', { input: 1_000_000, output: 0 })).toBe(3);
+    it('does not apply Claude rates to non-Claude models without explicit rates', () => {
+      expect(estimateCost('gpt-4', { input: 1_000_000, output: 0 })).toBe(0);
+    });
+
+    it('falls back to Sonnet rates for unknown Claude model aliases', () => {
+      expect(estimateCost('claude-future', { input: 1_000_000, output: 0 })).toBe(3);
     });
 
     it('returns 0 for zero tokens', () => {

--- a/claudeville/adapters/hermes.test.ts
+++ b/claudeville/adapters/hermes.test.ts
@@ -1,0 +1,96 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalHermesDir = process.env.HERMES_DIR;
+
+function writeJson(filePath: string, value: unknown) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+}
+
+function writeJsonl(filePath: string, values: unknown[]) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${values.map((value) => JSON.stringify(value)).join('\n')}\n`);
+}
+
+async function loadAdapter(hermesDir: string) {
+  process.env.HERMES_DIR = hermesDir;
+  vi.resetModules();
+  const mod = await import('./hermes.js');
+  return new mod.HermesAdapter();
+}
+
+describe('hermes adapter', () => {
+  afterEach(() => {
+    if (originalHermesDir === undefined) {
+      delete process.env.HERMES_DIR;
+    } else {
+      process.env.HERMES_DIR = originalHermesDir;
+    }
+    vi.resetModules();
+  });
+
+  it('reads active sessions from Hermes metadata and JSONL transcripts', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-adapter-'));
+    const now = Date.now();
+    const sessionId = '20260426_154631_8edf9b47';
+    const sessionFile = path.join(tmp, 'sessions', `session_${sessionId}.json`);
+    const transcriptFile = path.join(tmp, 'sessions', `${sessionId}.jsonl`);
+
+    writeJson(sessionFile, {
+      session_id: sessionId,
+      model: 'MiniMax-M2.7',
+      provider: 'minimax',
+      platform: 'telegram',
+      display_name: 'Lars',
+      session_start: '2026-04-26T15:46:31.886519',
+      last_updated: new Date(now - 1000).toISOString(),
+    });
+    writeJsonl(transcriptFile, [
+      { role: 'user', content: 'Please update docs', timestamp: '2026-04-26T15:46:35.000Z' },
+      { role: 'assistant', content: 'I will inspect the files.', timestamp: '2026-04-26T15:47:00.000Z' },
+      { role: 'tool', name: 'read_file', content: '{"path":"/tmp/demo.md"}', timestamp: '2026-04-26T15:48:00.000Z' },
+    ]);
+    fs.utimesSync(sessionFile, new Date(now - 1000), new Date(now - 1000));
+    fs.utimesSync(transcriptFile, new Date(now - 500), new Date(now - 500));
+
+    const adapter = await loadAdapter(tmp);
+    const sessions = await adapter.getActiveSessions(60_000);
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      sessionId: `hermes-${sessionId}`,
+      provider: 'hermes',
+      model: 'minimax/MiniMax-M2.7',
+      project: 'telegram:Lars',
+      lastTool: 'read_file',
+      lastToolInput: '{"path":"/tmp/demo.md"}',
+      lastMessage: 'I will inspect the files.',
+      filePath: transcriptFile,
+    });
+  });
+
+  it('returns detail from a Hermes transcript file path', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-adapter-'));
+    const transcriptFile = path.join(tmp, 'sessions', '20260426_154631_8edf9b47.jsonl');
+    writeJsonl(transcriptFile, [
+      { role: 'user', content: 'Hello', timestamp: '2026-04-26T15:46:35.000Z' },
+      { role: 'assistant', content: 'Hi there', timestamp: '2026-04-26T15:47:00.000Z' },
+      { role: 'tool', name: 'patch', content: '{"mode":"replace"}', timestamp: '2026-04-26T15:48:00.000Z' },
+    ]);
+
+    const adapter = await loadAdapter(tmp);
+    const detail = await adapter.getSessionDetail('hermes-20260426_154631_8edf9b47', null, transcriptFile);
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+    expect(detail.toolHistory).toEqual([{ tool: 'patch', detail: '{"mode":"replace"}', ts: Date.parse('2026-04-26T15:48:00.000Z') }]);
+    expect(detail.messages).toEqual([
+      { role: 'user', text: 'Hello', ts: Date.parse('2026-04-26T15:46:35.000Z') },
+      { role: 'assistant', text: 'Hi there', ts: Date.parse('2026-04-26T15:47:00.000Z') },
+    ]);
+  });
+});

--- a/claudeville/adapters/hermes.ts
+++ b/claudeville/adapters/hermes.ts
@@ -1,0 +1,205 @@
+/**
+ * Hermes Agent adapter
+ * Data source: HERMES_DIR or ~/.hermes/
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import type { AdapterSessionDetail, AgentAdapter, AgentSessionSummary, WatchPath } from '../../shared/types.js';
+import { debugAdapterError, parseJsonLines, readLines } from './jsonl-utils.js';
+
+const HERMES_DIR = process.env.HERMES_DIR || path.join(os.homedir(), '.hermes');
+const SESSIONS_DIR = path.join(HERMES_DIR, 'sessions');
+
+type SessionFile = { filePath: string; sessionId: string; mtime: number };
+
+async function readJson(filePath: string): Promise<any | null> {
+  try {
+    return JSON.parse(await fs.promises.readFile(filePath, 'utf-8'));
+  } catch (err) {
+    debugAdapterError('hermes', 'readJson', err, filePath);
+    return null;
+  }
+}
+
+function asTimestamp(value: unknown): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+  return 0;
+}
+
+function summarizeTool(entry: any): { tool: string; detail: string; ts: number } | null {
+  if (!entry || typeof entry !== 'object') return null;
+  const role = entry.role || entry.type;
+  const name = entry.name || entry.tool || entry.tool_name;
+  if (role !== 'tool' && !name && role !== 'tool_call') return null;
+
+  let detail = '';
+  const content = entry.content ?? entry.input ?? entry.arguments;
+  if (typeof content === 'string') detail = content;
+  else if (content?.command) detail = String(content.command);
+  else if (content) detail = JSON.stringify(content);
+
+  return {
+    tool: String(name || role || 'tool'),
+    detail: detail.substring(0, 80),
+    ts: asTimestamp(entry.timestamp ?? entry.created_at ?? entry.createdAt),
+  };
+}
+
+function summarizeMessage(entry: any): { role: string; text: string; ts: number } | null {
+  if (!entry || typeof entry !== 'object') return null;
+  const role = entry.role || entry.type;
+  if (role === 'tool' || role === 'tool_call') return null;
+
+  const content = entry.content ?? entry.text ?? entry.message?.content;
+  const text = typeof content === 'string'
+    ? content
+    : Array.isArray(content)
+      ? content.find((part: any) => part?.type === 'text' && part.text)?.text
+      : null;
+  if (!text || text.trim().length === 0) return null;
+
+  return {
+    role: role || 'assistant',
+    text: text.trim().substring(0, 200),
+    ts: asTimestamp(entry.timestamp ?? entry.created_at ?? entry.createdAt),
+  };
+}
+
+async function parseTranscript(filePath: string): Promise<AdapterSessionDetail & {
+  lastTool: string | null;
+  lastToolInput: string | null;
+  lastMessage: string | null;
+}> {
+  const lines = await readLines(filePath, { count: 120, scope: 'hermes' });
+  const entries = parseJsonLines(lines, 'hermes');
+  const toolHistory: Array<{ tool: string; detail: string; ts: number }> = [];
+  const messages: Array<{ role: string; text: string; ts: number }> = [];
+
+  for (const entry of entries) {
+    const tool = summarizeTool(entry);
+    if (tool) {
+      toolHistory.push(tool);
+      continue;
+    }
+    const message = summarizeMessage(entry);
+    if (message) messages.push(message);
+  }
+
+  const lastTool = toolHistory.at(-1) || null;
+  const lastMessage = [...messages].reverse().find((message) => message.role === 'assistant') || messages.at(-1) || null;
+
+  return {
+    toolHistory,
+    messages,
+    lastTool: lastTool?.tool || null,
+    lastToolInput: lastTool?.detail || null,
+    lastMessage: lastMessage?.text?.substring(0, 80) || null,
+  };
+}
+
+async function getSessionFiles(activeThresholdMs: number): Promise<SessionFile[]> {
+  if (!fs.existsSync(SESSIONS_DIR)) return [];
+  const now = Date.now();
+  try {
+    const entries = await fs.promises.readdir(SESSIONS_DIR, { withFileTypes: true });
+    const files = entries
+      .filter((entry) => entry.isFile() && entry.name.startsWith('session_') && entry.name.endsWith('.json'))
+      .map((entry) => path.join(SESSIONS_DIR, entry.name));
+    const stats = await Promise.all(files.map(async (filePath) => {
+      try {
+        const stat = await fs.promises.stat(filePath);
+        if (now - stat.mtimeMs > activeThresholdMs) return null;
+        const sessionId = path.basename(filePath, '.json').replace(/^session_/, '');
+        return { filePath, sessionId, mtime: stat.mtimeMs };
+      } catch (err) {
+        debugAdapterError('hermes', 'getSessionFiles stat', err, filePath);
+        return null;
+      }
+    }));
+    return stats.filter((result): result is SessionFile => result !== null);
+  } catch (err) {
+    debugAdapterError('hermes', 'getSessionFiles readdir', err, SESSIONS_DIR);
+    return [];
+  }
+}
+
+function transcriptPath(sessionId: string) {
+  return path.join(SESSIONS_DIR, `${sessionId}.jsonl`);
+}
+
+function modelName(metadata: any) {
+  if (metadata?.provider && metadata?.model) return `${metadata.provider}/${metadata.model}`;
+  return metadata?.model || 'hermes';
+}
+
+function projectName(metadata: any) {
+  const origin = metadata?.origin;
+  if (origin?.platform && (origin.chat_name || origin.chat_id)) return `${origin.platform}:${origin.chat_name || origin.chat_id}`;
+  if (metadata?.platform && metadata?.display_name) return `${metadata.platform}:${metadata.display_name}`;
+  if (metadata?.cwd) return metadata.cwd;
+  return metadata?.platform || null;
+}
+
+export class HermesAdapter implements AgentAdapter {
+  get name() { return 'Hermes Agent'; }
+  get provider() { return 'hermes'; }
+  get homeDir() { return HERMES_DIR; }
+
+  isAvailable() {
+    return fs.existsSync(HERMES_DIR);
+  }
+
+  async getActiveSessions(activeThresholdMs: number): Promise<AgentSessionSummary[]> {
+    const files = await getSessionFiles(activeThresholdMs);
+    const sessions = await Promise.all(files.map(async ({ filePath, sessionId, mtime }) => {
+      const metadata = await readJson(filePath);
+      const transcript = transcriptPath(sessionId);
+      const detail = fs.existsSync(transcript)
+        ? await parseTranscript(transcript)
+        : { lastTool: null, lastToolInput: null, lastMessage: null };
+      const updated = asTimestamp(metadata?.last_updated ?? metadata?.updated_at ?? metadata?.session_start) || mtime;
+
+      return {
+        sessionId: `hermes-${metadata?.session_id || sessionId}`,
+        provider: 'hermes',
+        agentId: null,
+        agentType: 'main',
+        model: modelName(metadata),
+        status: metadata?.suspended ? 'suspended' : 'active',
+        lastActivity: Math.max(updated, mtime),
+        project: projectName(metadata),
+        lastMessage: detail.lastMessage,
+        lastTool: detail.lastTool,
+        lastToolInput: detail.lastToolInput,
+        parentSessionId: null,
+        filePath: fs.existsSync(transcript) ? transcript : filePath,
+      };
+    }));
+
+    return sessions.sort((a, b) => b.lastActivity - a.lastActivity);
+  }
+
+  async getSessionDetail(sessionId: string, project: string | null, filePath: string | null = null): Promise<AdapterSessionDetail> {
+    if (filePath && filePath.endsWith('.jsonl')) {
+      const detail = await parseTranscript(filePath);
+      return { toolHistory: detail.toolHistory.slice(-15), messages: detail.messages.slice(-5), sessionId };
+    }
+
+    const cleanId = sessionId.replace(/^hermes-/, '');
+    const transcript = transcriptPath(cleanId);
+    if (!fs.existsSync(transcript)) return { toolHistory: [], messages: [] };
+    return this.getSessionDetail(sessionId, project, transcript);
+  }
+
+  getWatchPaths(): WatchPath[] {
+    return fs.existsSync(SESSIONS_DIR)
+      ? [{ type: 'directory', path: SESSIONS_DIR, recursive: false, filter: '.json' }]
+      : [];
+  }
+}

--- a/claudeville/adapters/index.fixture.test.ts
+++ b/claudeville/adapters/index.fixture.test.ts
@@ -52,6 +52,44 @@ describe('adapter registry fixtures', () => {
     ]);
     fs.utimesSync(openclawSession, new Date('2024-01-01T00:00:03Z'), new Date('2024-01-01T00:00:03Z'));
 
+    const opencodeSession = path.join(tmpHome, '.local', 'share', 'opencode', 'storage', 'session', 'demo-project', 'session-opencode.json');
+    writeJson(opencodeSession, {
+      id: 'session-opencode',
+      time: { created: '2024-01-01T00:00:04Z', updated: '2024-01-01T00:00:04Z' },
+      project: { path: workspaceDir },
+    });
+    const opencodeMessages = path.join(tmpHome, '.local', 'share', 'opencode', 'storage', 'message', 'demo-project', 'session-opencode.json');
+    writeJson(opencodeMessages, [
+      {
+        role: 'assistant',
+        modelID: 'anthropic/claude-sonnet-4-5',
+        parts: [
+          { type: 'tool-call', tool: 'bash', input: { command: 'npm test' } },
+          { type: 'text', text: 'OpenCode latest' },
+        ],
+        time: { created: '2024-01-01T00:00:04Z' },
+      },
+    ]);
+    fs.utimesSync(opencodeSession, new Date('2024-01-01T00:00:04Z'), new Date('2024-01-01T00:00:04Z'));
+
+    const hermesSessionId = '20240101_000005_abcdef';
+    const hermesSession = path.join(tmpHome, '.hermes', 'sessions', `session_${hermesSessionId}.json`);
+    writeJson(hermesSession, {
+      session_id: hermesSessionId,
+      provider: 'minimax',
+      model: 'MiniMax-M2.7',
+      platform: 'telegram',
+      display_name: 'Fixture Chat',
+      session_start: '2024-01-01T00:00:05Z',
+      last_updated: '2024-01-01T00:00:05Z',
+    });
+    const hermesTranscript = path.join(tmpHome, '.hermes', 'sessions', `${hermesSessionId}.jsonl`);
+    writeJsonl(hermesTranscript, [
+      JSON.stringify({ role: 'assistant', content: 'Hermes latest', timestamp: '2024-01-01T00:00:05Z' }),
+      JSON.stringify({ role: 'tool', name: 'patch', content: '{"mode":"replace"}', timestamp: '2024-01-01T00:00:05Z' }),
+    ]);
+    fs.utimesSync(hermesSession, new Date('2024-01-01T00:00:05Z'), new Date('2024-01-01T00:00:05Z'));
+
     process.env.HOME = tmpHome;
     vi.resetModules();
     registry = await import('./index.js');
@@ -71,6 +109,8 @@ describe('adapter registry fixtures', () => {
     const activeProviders = registry.getActiveProviders().map((provider: any) => provider.provider).sort();
     expect(activeProviders).toContain('gemini');
     expect(activeProviders).toContain('openclaw');
+    expect(activeProviders).toContain('opencode');
+    expect(activeProviders).toContain('hermes');
     // Pi may or may not be available depending on whether ~/.pi exists in the test environment
   });
 
@@ -84,6 +124,9 @@ describe('adapter registry fixtures', () => {
     expect(openclawSession).toBeDefined();
     expect(openclawSession.estimatedCost).toEqual(expect.any(Number));
     expect(openclawSession.detail.messages.length).toBeGreaterThan(0);
+
+    expect(sessions.find((s: any) => s.provider === 'opencode')).toBeDefined();
+    expect(sessions.find((s: any) => s.provider === 'hermes')).toBeDefined();
   });
 
   it('collects watch paths from active adapters only', () => {
@@ -93,8 +136,14 @@ describe('adapter registry fixtures', () => {
     // At minimum we expect gemini and openclaw paths; pi may add its sessions path
     const geminiPath = path.join(tmpHome, '.gemini', 'tmp', geminiHash, 'chats');
     const openclawPath = path.join(tmpHome, '.openclaw', 'agents', 'agent-alpha', 'sessions');
+    const opencodeSessionPath = path.join(tmpHome, '.local', 'share', 'opencode', 'storage', 'session');
+    const opencodeMessagePath = path.join(tmpHome, '.local', 'share', 'opencode', 'storage', 'message');
+    const hermesPath = path.join(tmpHome, '.hermes', 'sessions');
     expect(paths).toContain(geminiPath);
     expect(paths).toContain(openclawPath);
+    expect(paths).toContain(opencodeSessionPath);
+    expect(paths).toContain(opencodeMessagePath);
+    expect(paths).toContain(hermesPath);
   });
 
   it('returns empty detail for unknown providers', async () => {

--- a/claudeville/adapters/index.ts
+++ b/claudeville/adapters/index.ts
@@ -14,6 +14,8 @@ import { OpenClawAdapter } from './openclaw.js';
 import { CopilotAdapter } from './copilot.js';
 import { VSCodeAdapter } from './vscode.js';
 import { PiAdapter } from './pi.js';
+import { OpenCodeAdapter } from './opencode.js';
+import { HermesAdapter } from './hermes.js';
 
 export const adapters: AgentAdapter[] = [
   new ClaudeAdapter(),
@@ -23,6 +25,8 @@ export const adapters: AgentAdapter[] = [
   new CopilotAdapter(),
   new VSCodeAdapter(),
   new PiAdapter(),
+  new OpenCodeAdapter(),
+  new HermesAdapter(),
 ];
 
 /**

--- a/claudeville/adapters/opencode.test.ts
+++ b/claudeville/adapters/opencode.test.ts
@@ -1,0 +1,192 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { promisify } from 'util';
+import { execFile } from 'child_process';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalDataDir = process.env.OPENCODE_DATA_DIR;
+const execFileAsync = promisify(execFile);
+
+function writeJson(filePath: string, value: unknown) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+}
+
+async function loadAdapter(dataDir: string) {
+  process.env.OPENCODE_DATA_DIR = dataDir;
+  vi.resetModules();
+  const mod = await import('./opencode.js');
+  return new mod.OpenCodeAdapter();
+}
+
+describe('opencode adapter', () => {
+  afterEach(() => {
+    if (originalDataDir === undefined) {
+      delete process.env.OPENCODE_DATA_DIR;
+    } else {
+      process.env.OPENCODE_DATA_DIR = originalDataDir;
+    }
+    vi.resetModules();
+  });
+
+  it('reads active sessions from OpenCode storage asynchronously', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-adapter-'));
+    const now = Date.now();
+    const sessionFile = path.join(tmp, 'storage', 'session', 'demo-project', 'session-1.json');
+    const messageFile = path.join(tmp, 'storage', 'message', 'demo-project', 'session-1.json');
+
+    writeJson(sessionFile, {
+      id: 'session-1',
+      title: 'Fix dashboard',
+      time: { created: now - 5000, updated: now - 1000 },
+      project: { path: '/workspace/demo' },
+    });
+    writeJson(messageFile, [
+      { role: 'user', parts: [{ type: 'text', text: 'Please fix the dashboard' }], time: { created: now - 3000 } },
+      {
+        role: 'assistant',
+        modelID: 'anthropic/claude-sonnet-4-5',
+        parts: [
+          { type: 'tool-call', tool: 'bash', input: { command: 'npm test' } },
+          { type: 'text', text: 'Dashboard fixed' },
+        ],
+        time: { created: now - 1000 },
+      },
+    ]);
+    fs.utimesSync(sessionFile, new Date(now - 1000), new Date(now - 1000));
+
+    const adapter = await loadAdapter(tmp);
+    const sessions = await adapter.getActiveSessions(60_000);
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      sessionId: 'opencode-session-1',
+      provider: 'opencode',
+      project: '/workspace/demo',
+      model: 'anthropic/claude-sonnet-4-5',
+      lastTool: 'bash',
+      lastToolInput: 'npm test',
+      lastMessage: 'Dashboard fixed',
+      filePath: messageFile,
+    });
+  });
+
+  it('returns detail for an OpenCode message file path', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-adapter-'));
+    const messageFile = path.join(tmp, 'storage', 'message', 'demo-project', 'session-2.json');
+    writeJson(messageFile, [
+      { role: 'user', parts: [{ type: 'text', text: 'Run tests' }], time: { created: 1000 } },
+      { role: 'assistant', parts: [{ type: 'tool-call', tool: 'shell', input: { command: 'npm run test' } }], time: { created: 2000 } },
+      { role: 'assistant', parts: [{ type: 'text', text: 'All checked' }], time: { created: 3000 } },
+    ]);
+
+    const adapter = await loadAdapter(tmp);
+    const detail = await adapter.getSessionDetail('opencode-session-2', null, messageFile);
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+    expect(detail.toolHistory).toEqual([{ tool: 'shell', detail: 'npm run test', ts: 2000 }]);
+    expect(detail.messages).toEqual([
+      { role: 'user', text: 'Run tests', ts: 1000 },
+      { role: 'assistant', text: 'All checked', ts: 3000 },
+    ]);
+  });
+
+  it('reads active sessions from the OpenCode SQLite database when JSON session files are absent', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-adapter-'));
+    const dbPath = path.join(tmp, 'opencode.db');
+    const now = Date.now();
+    const sessionId = 'ses_live';
+    const projectId = 'project_live';
+    const messageId = 'msg_live';
+
+    await execFileAsync('sqlite3', [dbPath, `
+      CREATE TABLE project (
+        id text PRIMARY KEY,
+        worktree text NOT NULL,
+        vcs text,
+        name text,
+        icon_url text,
+        icon_color text,
+        time_created integer NOT NULL,
+        time_updated integer NOT NULL,
+        time_initialized integer,
+        sandboxes text NOT NULL
+      );
+      CREATE TABLE session (
+        id text PRIMARY KEY,
+        project_id text NOT NULL,
+        parent_id text,
+        slug text NOT NULL,
+        directory text NOT NULL,
+        title text NOT NULL,
+        version text NOT NULL,
+        share_url text,
+        summary_additions integer,
+        summary_deletions integer,
+        summary_files integer,
+        summary_diffs text,
+        revert text,
+        permission text,
+        time_created integer NOT NULL,
+        time_updated integer NOT NULL,
+        time_compacting integer,
+        time_archived integer,
+        workspace_id text
+      );
+      CREATE TABLE message (
+        id text PRIMARY KEY,
+        session_id text NOT NULL,
+        time_created integer NOT NULL,
+        time_updated integer NOT NULL,
+        data text NOT NULL
+      );
+      CREATE TABLE part (
+        id text PRIMARY KEY,
+        message_id text NOT NULL,
+        session_id text NOT NULL,
+        time_created integer NOT NULL,
+        time_updated integer NOT NULL,
+        data text NOT NULL
+      );
+      INSERT INTO project VALUES ('${projectId}', '/workspace/live', 'git', null, null, null, ${now - 10_000}, ${now - 10_000}, null, '[]');
+      INSERT INTO session VALUES ('${sessionId}', '${projectId}', null, 'live-session', '/workspace/live', 'Live OpenCode', '1.14.25', null, 0, 0, 0, null, null, null, ${now - 5_000}, ${now - 500}, null, null, null);
+      INSERT INTO message VALUES ('${messageId}', '${sessionId}', ${now - 500}, ${now - 400}, '${JSON.stringify({
+        role: 'assistant',
+        modelID: 'moonshotai/kimi-k2.6:thinking',
+        providerID: 'nano-gpt',
+        time: { created: now - 500 },
+      }).replace(/'/g, "''")}');
+      INSERT INTO part VALUES ('prt_text', '${messageId}', '${sessionId}', ${now - 450}, ${now - 450}, '${JSON.stringify({
+        type: 'text',
+        text: 'Live db message',
+      }).replace(/'/g, "''")}');
+      INSERT INTO part VALUES ('prt_tool', '${messageId}', '${sessionId}', ${now - 425}, ${now - 425}, '${JSON.stringify({
+        type: 'tool',
+        tool: 'read',
+        state: { input: { filePath: '/workspace/live/file.ts' } },
+      }).replace(/'/g, "''")}');
+    `]);
+
+    const adapter = await loadAdapter(tmp);
+    const sessions = await adapter.getActiveSessions(60_000);
+    const detail = await adapter.getSessionDetail('opencode-ses_live', '/workspace/live', 'opencode-db:ses_live');
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      sessionId: 'opencode-ses_live',
+      provider: 'opencode',
+      project: '/workspace/live',
+      model: 'moonshotai/kimi-k2.6:thinking',
+      lastTool: 'read',
+      lastToolInput: '/workspace/live/file.ts',
+      lastMessage: 'Live db message',
+      filePath: 'opencode-db:ses_live',
+    });
+    expect(detail.messages).toEqual([{ role: 'assistant', text: 'Live db message', ts: now - 450 }]);
+    expect(detail.toolHistory).toEqual([{ tool: 'read', detail: '/workspace/live/file.ts', ts: now - 425 }]);
+  });
+});

--- a/claudeville/adapters/opencode.ts
+++ b/claudeville/adapters/opencode.ts
@@ -1,0 +1,463 @@
+/**
+ * OpenCode CLI adapter
+ * Data source: OPENCODE_DATA_DIR or ~/.local/share/opencode/
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+import type { AgentAdapter, AdapterSessionDetail, AgentSessionSummary, WatchPath } from '../../shared/types.js';
+import { debugAdapterError } from './jsonl-utils.js';
+
+const OPENCODE_DIR = process.env.OPENCODE_DATA_DIR || path.join(os.homedir(), '.local', 'share', 'opencode');
+const STORAGE_DIR = path.join(OPENCODE_DIR, 'storage');
+const SESSION_DIR = path.join(STORAGE_DIR, 'session');
+const MESSAGE_DIR = path.join(STORAGE_DIR, 'message');
+const DB_FILE = path.join(OPENCODE_DIR, 'opencode.db');
+const execFileAsync = promisify(execFile);
+
+type Dirent = { name: string; isDirectory(): boolean; isFile(): boolean };
+type SessionFile = { filePath: string; sessionId: string; projectKey: string; mtime: number };
+type DbSession = {
+  id: string;
+  project_id: string;
+  parent_id: string | null;
+  directory: string;
+  title: string;
+  time_created: number;
+  time_updated: number;
+  modelID?: string | null;
+  providerID?: string | null;
+};
+type DbMessage = {
+  id: string;
+  role: string;
+  modelID?: string | null;
+  providerID?: string | null;
+  time_created: number;
+  data: any;
+  parts: Array<{ id: string; time_created: number; data: any }>;
+};
+
+async function collectJsonFiles(root: string): Promise<string[]> {
+  try {
+    const entries = await fs.promises.readdir(root, { withFileTypes: true });
+    const groups = await Promise.all(entries.map(async (entry: Dirent) => {
+      const entryPath = path.join(root, entry.name);
+      if (entry.isDirectory()) return collectJsonFiles(entryPath);
+      if (entry.isFile() && entry.name.endsWith('.json')) return [entryPath];
+      return [];
+    }));
+    return groups.flat();
+  } catch (err) {
+    debugAdapterError('opencode', 'collectJsonFiles', err, root);
+    return [];
+  }
+}
+
+async function readJson(filePath: string): Promise<any | null> {
+  try {
+    return JSON.parse(await fs.promises.readFile(filePath, 'utf-8'));
+  } catch (err) {
+    debugAdapterError('opencode', 'readJson', err, filePath);
+    return null;
+  }
+}
+
+async function queryDb<T>(sql: string, params: string[] = []): Promise<T[]> {
+  if (!fs.existsSync(DB_FILE)) return [];
+  try {
+    let renderedSql = sql;
+    for (const param of params) {
+      renderedSql = renderedSql.replace('?', `'${param.replace(/'/g, "''")}'`);
+    }
+    const { stdout } = await execFileAsync('sqlite3', ['-json', DB_FILE, renderedSql], { maxBuffer: 10 * 1024 * 1024 });
+    if (!stdout.trim()) return [];
+    return JSON.parse(stdout) as T[];
+  } catch (err) {
+    debugAdapterError('opencode', 'queryDb', err, DB_FILE);
+    return [];
+  }
+}
+
+function asTimestamp(value: unknown): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+  return 0;
+}
+
+function textFromPart(part: any): string | null {
+  if (!part) return null;
+  if (typeof part === 'string') return part;
+  if (typeof part.text === 'string') return part.text;
+  if (typeof part.content === 'string') return part.content;
+  return null;
+}
+
+function toolFromPart(part: any): { tool: string; detail: string } | null {
+  if (!part || typeof part !== 'object') return null;
+  const type = part.type || part.kind;
+  const tool = part.tool || part.name || part.toolName;
+  if (!tool && type !== 'tool-call' && type !== 'tool_use') return null;
+
+  const input = part.input ?? part.args ?? part.arguments ?? part.state?.input;
+  let detail = '';
+  if (typeof input === 'string') detail = input;
+  else if (input?.command) detail = String(input.command);
+  else if (input?.filePath) detail = String(input.filePath);
+  else if (input?.file_path) detail = String(input.file_path);
+  else if (input) detail = JSON.stringify(input);
+
+  return { tool: String(tool || type || 'tool'), detail: detail.substring(0, 80) };
+}
+
+function dbToolFromPart(part: any): { tool: string; detail: string } | null {
+  return toolFromPart(part);
+}
+
+function normalizeMessages(raw: any): any[] {
+  if (Array.isArray(raw)) return raw;
+  if (Array.isArray(raw?.messages)) return raw.messages;
+  if (Array.isArray(raw?.items)) return raw.items;
+  return [];
+}
+
+function extractMessageTs(message: any): number {
+  return asTimestamp(message?.time?.created ?? message?.time?.updated ?? message?.created ?? message?.createdAt ?? message?.timestamp);
+}
+
+function normalizeDbJson(value: unknown) {
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeModel(value: unknown, provider: unknown = null): string | null {
+  if (!value) return null;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'object') {
+    const model = value as { modelID?: unknown; modelId?: unknown; id?: unknown; providerID?: unknown; providerId?: unknown };
+    const modelId = model.modelID || model.modelId || model.id;
+    const providerId = model.providerID || model.providerId || provider;
+    if (typeof modelId === 'string' && typeof providerId === 'string') return `${providerId}/${modelId}`;
+    if (typeof modelId === 'string') return modelId;
+  }
+  return null;
+}
+
+function extractDetail(messages: any[]): AdapterSessionDetail & {
+  model: string | null;
+  lastTool: string | null;
+  lastToolInput: string | null;
+  lastMessage: string | null;
+} {
+  const detail = {
+    toolHistory: [] as Array<{ tool: string; detail: string; ts: number }>,
+    messages: [] as Array<{ role: string; text: string; ts: number }>,
+    model: null as string | null,
+    lastTool: null as string | null,
+    lastToolInput: null as string | null,
+    lastMessage: null as string | null,
+  };
+
+  for (const message of messages) {
+    const ts = extractMessageTs(message);
+    const role = message.role || message.type || 'assistant';
+    if (!detail.model && (message.modelID || message.model || message.modelId)) {
+      detail.model = message.modelID || message.model || message.modelId;
+    }
+
+    const parts = Array.isArray(message.parts)
+      ? message.parts
+      : Array.isArray(message.content)
+        ? message.content
+        : [{ text: message.content ?? message.text }];
+
+    for (const part of parts) {
+      const tool = toolFromPart(part);
+      if (tool) {
+        detail.toolHistory.push({ ...tool, ts });
+        detail.lastTool = tool.tool;
+        detail.lastToolInput = tool.detail;
+        continue;
+      }
+
+      const text = textFromPart(part);
+      if (!text || text.trim().length === 0) continue;
+      const trimmed = text.trim();
+      detail.messages.push({ role, text: trimmed.substring(0, 200), ts });
+      if (role === 'assistant') detail.lastMessage = trimmed.substring(0, 80);
+    }
+  }
+
+  return detail;
+}
+
+async function getSessionFiles(activeThresholdMs: number): Promise<SessionFile[]> {
+  if (!fs.existsSync(SESSION_DIR)) return [];
+  const now = Date.now();
+  const files = await collectJsonFiles(SESSION_DIR);
+  const stats = await Promise.all(files.map(async (filePath) => {
+    try {
+      const stat = await fs.promises.stat(filePath);
+      if (now - stat.mtimeMs > activeThresholdMs) return null;
+      const sessionId = path.basename(filePath, '.json');
+      const projectKey = path.basename(path.dirname(filePath));
+      return { filePath, sessionId, projectKey, mtime: stat.mtimeMs };
+    } catch (err) {
+      debugAdapterError('opencode', 'getSessionFiles stat', err, filePath);
+      return null;
+    }
+  }));
+  return stats.filter((result): result is SessionFile => result !== null);
+}
+
+function extractDbDetail(messages: DbMessage[]): AdapterSessionDetail & {
+  model: string | null;
+  lastTool: string | null;
+  lastToolInput: string | null;
+  lastMessage: string | null;
+} {
+  const detail = {
+    toolHistory: [] as Array<{ tool: string; detail: string; ts: number }>,
+    messages: [] as Array<{ role: string; text: string; ts: number }>,
+    model: null as string | null,
+    lastTool: null as string | null,
+    lastToolInput: null as string | null,
+    lastMessage: null as string | null,
+  };
+
+  for (const message of messages) {
+    const messageData = normalizeDbJson(message.data) as any;
+    const role = messageData?.role || message.role || 'assistant';
+    if (!detail.model && (messageData?.modelID || messageData?.model || message.modelID)) {
+      detail.model = normalizeModel(messageData?.modelID || messageData?.model || message.modelID, messageData?.providerID || message.providerID);
+    }
+
+    for (const part of message.parts) {
+      const partData = normalizeDbJson(part.data) as any;
+      const tool = dbToolFromPart(partData);
+      if (tool) {
+        detail.toolHistory.push({ ...tool, ts: part.time_created || message.time_created });
+        detail.lastTool = tool.tool;
+        detail.lastToolInput = tool.detail;
+        continue;
+      }
+
+      const text = textFromPart(partData);
+      if (!text || text.trim().length === 0) continue;
+      const trimmed = text.trim();
+      detail.messages.push({ role, text: trimmed.substring(0, 200), ts: part.time_created || message.time_created });
+      if (role === 'assistant') detail.lastMessage = trimmed.substring(0, 80);
+    }
+  }
+
+  return detail;
+}
+
+async function getDbMessages(sessionId: string, limit = 30): Promise<DbMessage[]> {
+  const rows = await queryDb<{
+    message_id: string;
+    message_time_created: number;
+    message_data: string;
+    part_id: string | null;
+    part_time_created: number | null;
+    part_data: string | null;
+  }>(
+    `SELECT
+       recent.id AS message_id,
+       recent.time_created AS message_time_created,
+       recent.data AS message_data,
+       p.id AS part_id,
+       p.time_created AS part_time_created,
+       p.data AS part_data
+     FROM (
+       SELECT id, time_created, data
+       FROM message
+       WHERE session_id = ?
+       ORDER BY time_created DESC
+       LIMIT ${limit}
+     ) recent
+     LEFT JOIN part p ON p.message_id = recent.id
+     ORDER BY recent.time_created ASC, p.time_created ASC`,
+    [sessionId],
+  );
+
+  const messageMap = new Map<string, DbMessage>();
+  for (const row of rows) {
+    let message = messageMap.get(row.message_id);
+    if (!message) {
+      const messageData = normalizeDbJson(row.message_data) as any;
+      message = {
+        id: row.message_id,
+        role: messageData?.role || 'assistant',
+        modelID: messageData?.modelID || null,
+        providerID: messageData?.providerID || null,
+        time_created: row.message_time_created,
+        data: messageData,
+        parts: [],
+      };
+      messageMap.set(row.message_id, message);
+    }
+
+    if (row.part_id && row.part_data) {
+      message.parts.push({
+        id: row.part_id,
+        time_created: row.part_time_created || row.message_time_created,
+        data: normalizeDbJson(row.part_data),
+      });
+    }
+  }
+
+  return Array.from(messageMap.values());
+}
+
+async function getDbSessions(activeThresholdMs: number): Promise<DbSession[]> {
+  if (!fs.existsSync(DB_FILE)) return [];
+  const cutoff = Date.now() - activeThresholdMs;
+  const rows = await queryDb<DbSession & { message_model: string | null; message_provider: string | null }>(
+    `SELECT
+       s.id,
+       s.project_id,
+       s.parent_id,
+       s.directory,
+       s.title,
+       s.time_created,
+       s.time_updated,
+       (
+         SELECT json_extract(m.data, '$.modelID')
+         FROM message m
+         WHERE m.session_id = s.id
+         ORDER BY m.time_created DESC
+         LIMIT 1
+       ) AS message_model,
+       (
+         SELECT json_extract(m.data, '$.providerID')
+         FROM message m
+         WHERE m.session_id = s.id
+         ORDER BY m.time_created DESC
+         LIMIT 1
+       ) AS message_provider
+     FROM session s
+     WHERE s.time_updated >= ?
+       AND s.time_archived IS NULL
+     ORDER BY s.time_updated DESC`,
+    [String(cutoff)],
+  );
+
+  return rows.map((row) => ({
+    ...row,
+    modelID: row.message_model || null,
+    providerID: row.message_provider || null,
+  }));
+}
+
+function resolveMessageFile(projectKey: string, sessionId: string) {
+  return path.join(MESSAGE_DIR, projectKey, `${sessionId}.json`);
+}
+
+function projectFromSession(session: any, projectKey: string): string | null {
+  return session?.project?.path || session?.cwd || session?.path || session?.directory || projectKey || null;
+}
+
+export class OpenCodeAdapter implements AgentAdapter {
+  get name() { return 'OpenCode'; }
+  get provider() { return 'opencode'; }
+  get homeDir() { return OPENCODE_DIR; }
+
+  isAvailable() {
+    return fs.existsSync(OPENCODE_DIR);
+  }
+
+  async getActiveSessions(activeThresholdMs: number): Promise<AgentSessionSummary[]> {
+    const dbSessions = await getDbSessions(activeThresholdMs);
+    if (dbSessions.length > 0) {
+      const sessions = await Promise.all(dbSessions.map(async (session) => {
+        const messages = await getDbMessages(session.id);
+        const detail = extractDbDetail(messages);
+        return {
+          sessionId: `opencode-${session.id}`,
+          provider: 'opencode',
+          agentId: null,
+          agentType: 'main',
+          model: detail.model || normalizeModel(session.modelID, session.providerID) || 'opencode',
+          status: 'active',
+          lastActivity: session.time_updated,
+          project: session.directory || session.project_id || null,
+          lastMessage: detail.lastMessage,
+          lastTool: detail.lastTool,
+          lastToolInput: detail.lastToolInput,
+          parentSessionId: session.parent_id || null,
+          filePath: `opencode-db:${session.id}`,
+        };
+      }));
+      return sessions.sort((a, b) => b.lastActivity - a.lastActivity);
+    }
+
+    const files = await getSessionFiles(activeThresholdMs);
+    const sessions = await Promise.all(files.map(async ({ filePath, sessionId, projectKey, mtime }) => {
+      const [session, rawMessages] = await Promise.all([
+        readJson(filePath),
+        readJson(resolveMessageFile(projectKey, sessionId)),
+      ]);
+      const messageFile = resolveMessageFile(projectKey, sessionId);
+      const detail = extractDetail(normalizeMessages(rawMessages));
+      const updated = asTimestamp(session?.time?.updated ?? session?.updatedAt ?? session?.updated) || mtime;
+
+      return {
+        sessionId: `opencode-${session?.id || sessionId}`,
+        provider: 'opencode',
+        agentId: null,
+        agentType: session?.agent || 'main',
+        model: detail.model || session?.model || 'opencode',
+        status: 'active',
+        lastActivity: Math.max(updated, mtime),
+        project: projectFromSession(session, projectKey),
+        lastMessage: detail.lastMessage,
+        lastTool: detail.lastTool,
+        lastToolInput: detail.lastToolInput,
+        parentSessionId: session?.parentID || session?.parentId || null,
+        filePath: fs.existsSync(messageFile) ? messageFile : filePath,
+      };
+    }));
+
+    return sessions.sort((a, b) => b.lastActivity - a.lastActivity);
+  }
+
+  async getSessionDetail(sessionId: string, project: string | null, filePath: string | null = null): Promise<AdapterSessionDetail> {
+    if (filePath?.startsWith('opencode-db:')) {
+      const dbSessionId = filePath.replace('opencode-db:', '');
+      const detail = extractDbDetail(await getDbMessages(dbSessionId, 60));
+      return { toolHistory: detail.toolHistory.slice(-15), messages: detail.messages.slice(-5), sessionId };
+    }
+
+    const raw = filePath ? await readJson(filePath) : null;
+    if (raw) {
+      const detail = extractDetail(normalizeMessages(raw));
+      return { toolHistory: detail.toolHistory.slice(-15), messages: detail.messages.slice(-5), sessionId };
+    }
+
+    const cleanId = sessionId.replace(/^opencode-/, '');
+    const files = await getSessionFiles(30 * 60 * 1000);
+    const match = files.find((file) => file.sessionId === cleanId);
+    if (!match) return { toolHistory: [], messages: [] };
+
+    return this.getSessionDetail(sessionId, project, resolveMessageFile(match.projectKey, cleanId));
+  }
+
+  getWatchPaths(): WatchPath[] {
+    const paths: WatchPath[] = [];
+    if (fs.existsSync(DB_FILE)) paths.push({ type: 'file', path: DB_FILE });
+    if (fs.existsSync(SESSION_DIR)) paths.push({ type: 'directory', path: SESSION_DIR, recursive: true, filter: '.json' });
+    if (fs.existsSync(MESSAGE_DIR)) paths.push({ type: 'directory', path: MESSAGE_DIR, recursive: true, filter: '.json' });
+    return paths;
+  }
+}

--- a/claudeville/src/config/costs.test.ts
+++ b/claudeville/src/config/costs.test.ts
@@ -42,9 +42,14 @@ describe('costs', () => {
       expect(cost).toBe(4.8);
     });
 
-    it('falls back to Sonnet for unknown models', () => {
-      const cost = estimateClaudeCost('unknown-model', { input: 1_000_000, output: 1_000_000 });
+    it('falls back to Sonnet for unknown Claude model aliases', () => {
+      const cost = estimateClaudeCost('claude-future', { input: 1_000_000, output: 1_000_000 });
       expect(cost).toBe(18);
+    });
+
+    it('returns 0 for non-Claude models without explicit rates', () => {
+      const cost = estimateClaudeCost('gpt-4', { input: 1_000_000, output: 1_000_000 });
+      expect(cost).toBe(0);
     });
 
     it('returns 0 for zero tokens', () => {

--- a/claudeville/src/domain/entities/Agent.test.ts
+++ b/claudeville/src/domain/entities/Agent.test.ts
@@ -156,9 +156,14 @@ describe('Agent', () => {
       expect(agent.cost).toBe(0);
     });
 
-    it('uses unknown model rate (falls back to Sonnet)', () => {
-      const agent = new Agent(makeProps({ model: 'unknown-model', tokens: { input: 1_000_000, output: 0 } }));
+    it('falls back to Sonnet rates for unknown Claude model aliases', () => {
+      const agent = new Agent(makeProps({ model: 'claude-future', tokens: { input: 1_000_000, output: 0 } }));
       expect(agent.cost).toBe(3); // Sonnet input rate
+    });
+
+    it('returns 0 for non-Claude models without explicit rates', () => {
+      const agent = new Agent(makeProps({ model: 'unknown-model', tokens: { input: 1_000_000, output: 0 } }));
+      expect(agent.cost).toBe(0);
     });
   });
 

--- a/claudeville/src/presentation/react/ClaudeVilleApp.test.tsx
+++ b/claudeville/src/presentation/react/ClaudeVilleApp.test.tsx
@@ -181,6 +181,18 @@ describe('ClaudeVilleApp', () => {
     expect(controllerMock.dispose).toHaveBeenCalledTimes(1);
   });
 
+  it('logs boot failures while the controller exposes the boot error snapshot', async () => {
+    const error = new Error('boot exploded');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    controllerMock.boot.mockRejectedValueOnce(error);
+
+    render(<ClaudeVilleApp />);
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith('[ClaudeVille] boot failed', error);
+    });
+  });
+
   it('wires the shell controls to the controller and keeps the sidebar agent clickable', async () => {
     render(<ClaudeVilleApp />);
 

--- a/claudeville/src/presentation/react/ClaudeVilleApp.tsx
+++ b/claudeville/src/presentation/react/ClaudeVilleApp.tsx
@@ -21,8 +21,9 @@ export function ClaudeVilleApp() {
   const stats = snapshot.world.getStats();
 
   useEffect(() => {
-    void controller.boot().catch(() => {
+    void controller.boot().catch((error) => {
       // Error state is exposed through the controller snapshot.
+      console.error('[ClaudeVille] boot failed', error);
     });
 
     return () => {

--- a/claudeville/src/presentation/react/world/components/AgentActor.test.tsx
+++ b/claudeville/src/presentation/react/world/components/AgentActor.test.tsx
@@ -1,11 +1,22 @@
 /** @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render } from '@testing-library/react';
+import { act, cleanup, render, renderHook } from '@testing-library/react';
 
 import type { BubbleConfig } from '../types.js';
 import { Accessory, Bubble, Hair, NameTag } from './AgentActor.js';
+import { useInverseZoom } from '../hooks/useInverseZoom.js';
 import { createPolygonGeometry, createRoundedRectGeometry } from '../utils.js';
+
+const frameCallbacks = vi.hoisted(() => ({
+  current: [] as Array<() => void>,
+}));
+
+vi.mock('@react-three/fiber', () => ({
+  useFrame: (callback: () => void) => {
+    frameCallbacks.current.push(callback);
+  },
+}));
 
 vi.mock('../utils.js', () => ({
   createPolygonGeometry: vi.fn(() => ({ type: 'polygon-geometry' })),
@@ -28,6 +39,7 @@ const bubbleConfig: BubbleConfig = {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  frameCallbacks.current = [];
 });
 
 describe('AgentActor geometry creation', () => {
@@ -58,5 +70,30 @@ describe('AgentActor geometry creation', () => {
 
     expect(createRoundedRectGeometry).toHaveBeenCalledTimes(1);
     expect(createPolygonGeometry).toHaveBeenCalledTimes(2);
+  });
+
+  it('updates inverse zoom from the camera during frame updates', () => {
+    const cameraRef = {
+      current: {
+        x: 0,
+        y: 0,
+        zoom: 1,
+        minZoom: 0.5,
+        maxZoom: 4,
+        viewportWidth: 100,
+        viewportHeight: 100,
+        followAgentId: null,
+        followSmoothing: 0,
+      },
+    };
+    const { result } = renderHook(() => useInverseZoom(cameraRef));
+    expect(result.current).toBe(1);
+
+    act(() => {
+      cameraRef.current.zoom = 2;
+      frameCallbacks.current.forEach((callback) => callback());
+    });
+
+    expect(result.current).toBe(0.5);
   });
 });

--- a/claudeville/src/presentation/react/world/components/AgentActor.tsx
+++ b/claudeville/src/presentation/react/world/components/AgentActor.tsx
@@ -8,6 +8,7 @@ import type { AgentSprite } from '../../../character-mode/AgentSprite.js';
 import { THEME } from '../../../../config/theme.js';
 import { AgentStatus } from '../../../../domain/value-objects/AgentStatus.js';
 import type { BubbleConfig, CameraModel } from '../types.js';
+import { useInverseZoom } from '../hooks/useInverseZoom.js';
 import { createPolygonGeometry, createRoundedRectGeometry } from '../utils.js';
 import { WorldText } from './WorldText.js';
 
@@ -257,7 +258,7 @@ export function AgentActor({
     groupRef.current.position.set(Math.round(sprite.x), Math.round(sprite.y), depth);
   });
 
-  const inverseZoom = 1 / cameraRef.current.zoom;
+  const inverseZoom = useInverseZoom(cameraRef);
   const swing = sprite.moving ? Math.sin(sprite.walkFrame * 4) * 4 : 0;
   const app = sprite.agent.appearance;
   const bubbleText = sprite.agent.bubbleText;

--- a/claudeville/src/presentation/react/world/hooks/useInverseZoom.ts
+++ b/claudeville/src/presentation/react/world/hooks/useInverseZoom.ts
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+import type { MutableRefObject } from 'react';
+
+import { useFrame } from '@react-three/fiber';
+
+import type { CameraModel } from '../types.js';
+
+export function useInverseZoom(cameraRef: MutableRefObject<CameraModel>) {
+  const [inverseZoom, setInverseZoom] = useState(() => 1 / cameraRef.current.zoom);
+
+  useFrame(() => {
+    const nextInverseZoom = 1 / cameraRef.current.zoom;
+    setInverseZoom((current) => current === nextInverseZoom ? current : nextInverseZoom);
+  });
+
+  return inverseZoom;
+}

--- a/collector/collector.test.ts
+++ b/collector/collector.test.ts
@@ -55,11 +55,12 @@ describe('collector', () => {
       expect(haikuCost).toBe(4.8);
     });
 
-    it('estimateCost falls back to sonnet rate for unknown models', () => {
+    it('estimateCost falls back to sonnet rate for unknown Claude aliases only', () => {
       const tokens = { input: 1000000, output: 1000000 };
-      const cost = estimateCost('unknown-model', tokens);
+      const cost = estimateCost('claude-future', tokens);
       // Falls back to sonnet: 1M * 3 + 1M * 15 = $18
       expect(cost).toBe(18);
+      expect(estimateCost('unknown-model', tokens)).toBe(0);
     });
 
     it('normalizeSession handles missing tokenUsage', () => {

--- a/collector/index.test.ts
+++ b/collector/index.test.ts
@@ -23,9 +23,14 @@ describe('collector logic', () => {
       expect(cost).toBe(4.8);
     });
 
-    it('falls back to Sonnet for unknown models', () => {
-      const cost = estimateCost('unknown-model', { input: 1000000, output: 1000000 });
+    it('falls back to Sonnet for unknown Claude model aliases', () => {
+      const cost = estimateCost('claude-future', { input: 1000000, output: 1000000 });
       expect(cost).toBe(18); // Sonnet rate
+    });
+
+    it('returns 0 for non-Claude models without explicit rates', () => {
+      const cost = estimateCost('unknown-model', { input: 1000000, output: 1000000 });
+      expect(cost).toBe(0);
     });
 
     it('handles zero tokens', () => {

--- a/hubreceiver/state.ts
+++ b/hubreceiver/state.ts
@@ -28,6 +28,22 @@ export function defaultUsage() {
 
 const collectors = new Map();
 
+type AnyRecord = Record<string, any>;
+type DetailMessage = { role?: string; text?: string; ts?: number };
+type SessionDetail = { messages?: DetailMessage[]; toolHistory?: unknown[]; tokenUsage?: unknown; sessionId?: string };
+type Usage = ReturnType<typeof defaultUsage> | AnyRecord;
+type NormalizedSnapshot = {
+  collectorId: string;
+  hostName: string;
+  timestamp: number;
+  sessions: AnyRecord[];
+  teams: AnyRecord[];
+  taskGroups: AnyRecord[];
+  providers: AnyRecord[];
+  usage: Usage;
+  sessionDetails: Record<string, unknown>;
+};
+
 interface SnapshotInput {
   collectorId?: string;
   hostName?: string;
@@ -45,11 +61,11 @@ function normalizeSnapshot(snapshot: SnapshotInput) {
     collectorId: snapshot.collectorId || 'default',
     hostName: snapshot.hostName || 'unknown',
     timestamp: Number(snapshot.timestamp || Date.now()),
-    sessions: Array.isArray(snapshot.sessions) ? snapshot.sessions : [],
-    teams: Array.isArray(snapshot.teams) ? snapshot.teams : [],
-    taskGroups: Array.isArray(snapshot.taskGroups) ? snapshot.taskGroups : [],
-    providers: Array.isArray(snapshot.providers) ? snapshot.providers : [],
-    usage: snapshot.usage || defaultUsage(),
+    sessions: Array.isArray(snapshot.sessions) ? snapshot.sessions as AnyRecord[] : [],
+    teams: Array.isArray(snapshot.teams) ? snapshot.teams as AnyRecord[] : [],
+    taskGroups: Array.isArray(snapshot.taskGroups) ? snapshot.taskGroups as AnyRecord[] : [],
+    providers: Array.isArray(snapshot.providers) ? snapshot.providers as AnyRecord[] : [],
+    usage: (snapshot.usage || defaultUsage()) as Usage,
     sessionDetails: snapshot.sessionDetails && typeof snapshot.sessionDetails === 'object'
       ? snapshot.sessionDetails
       : {},
@@ -63,17 +79,17 @@ export function applySnapshot(snapshot: SnapshotInput) {
 }
 
 export function getCurrentState() {
-  const sessionMap = new Map();
-  const teamMap = new Map();
-  const taskMap = new Map();
-  const providerMap = new Map();
-  const detailMap = new Map();
+  const sessionMap = new Map<string, Record<string, any>>();
+  const teamMap = new Map<string, Record<string, any>>();
+  const taskMap = new Map<string, Record<string, any>>();
+  const providerMap = new Map<string, Record<string, any>>();
+  const detailMap = new Map<string, SessionDetail>();
 
-  let latestUsage = defaultUsage();
+  let latestUsage: Usage = defaultUsage();
   let latestUsageTs = 0;
   let latestTimestamp = 0;
 
-  for (const snapshot of collectors.values()) {
+  for (const snapshot of collectors.values() as Iterable<NormalizedSnapshot>) {
     latestTimestamp = Math.max(latestTimestamp, snapshot.timestamp);
 
     for (const session of snapshot.sessions) {
@@ -107,7 +123,7 @@ export function getCurrentState() {
     }
 
     for (const [key, detail] of Object.entries(snapshot.sessionDetails)) {
-      detailMap.set(key, detail);
+      detailMap.set(key, detail as SessionDetail);
     }
 
     if (snapshot.usage && snapshot.timestamp >= latestUsageTs) {

--- a/runtime-config.shared.ts
+++ b/runtime-config.shared.ts
@@ -17,6 +17,9 @@ export function readProviderNameModes(env = process.env) {
     gemini: env.CLAUDEVILLE_NAME_MODE_GEMINI,
     openclaw: env.CLAUDEVILLE_NAME_MODE_OPENCLAW,
     copilot: env.CLAUDEVILLE_NAME_MODE_COPILOT,
+    pi: env.CLAUDEVILLE_NAME_MODE_PI,
+    opencode: env.CLAUDEVILLE_NAME_MODE_OPENCODE,
+    hermes: env.CLAUDEVILLE_NAME_MODE_HERMES,
   };
 
   const modes: Record<string, string> = {};

--- a/runtime-config.test.ts
+++ b/runtime-config.test.ts
@@ -136,6 +136,9 @@ describe('runtime config', () => {
           gemini: env.CLAUDEVILLE_NAME_MODE_GEMINI,
           openclaw: env.CLAUDEVILLE_NAME_MODE_OPENCLAW,
           copilot: env.CLAUDEVILLE_NAME_MODE_COPILOT,
+          pi: env.CLAUDEVILLE_NAME_MODE_PI,
+          opencode: env.CLAUDEVILLE_NAME_MODE_OPENCODE,
+          hermes: env.CLAUDEVILLE_NAME_MODE_HERMES,
         };
 
         const modes: Record<string, string> = {};
@@ -159,6 +162,9 @@ describe('runtime config', () => {
           gemini: env.CLAUDEVILLE_NAME_MODE_GEMINI,
           openclaw: env.CLAUDEVILLE_NAME_MODE_OPENCLAW,
           copilot: env.CLAUDEVILLE_NAME_MODE_COPILOT,
+          pi: env.CLAUDEVILLE_NAME_MODE_PI,
+          opencode: env.CLAUDEVILLE_NAME_MODE_OPENCODE,
+          hermes: env.CLAUDEVILLE_NAME_MODE_HERMES,
         };
 
         const modes: Record<string, string> = {};
@@ -183,6 +189,9 @@ describe('runtime config', () => {
           gemini: env.CLAUDEVILLE_NAME_MODE_GEMINI,
           openclaw: env.CLAUDEVILLE_NAME_MODE_OPENCLAW,
           copilot: env.CLAUDEVILLE_NAME_MODE_COPILOT,
+          pi: env.CLAUDEVILLE_NAME_MODE_PI,
+          opencode: env.CLAUDEVILLE_NAME_MODE_OPENCODE,
+          hermes: env.CLAUDEVILLE_NAME_MODE_HERMES,
         };
 
         const modes: Record<string, string> = {};
@@ -213,6 +222,9 @@ describe('runtime config', () => {
           gemini: env.CLAUDEVILLE_NAME_MODE_GEMINI,
           openclaw: env.CLAUDEVILLE_NAME_MODE_OPENCLAW,
           copilot: env.CLAUDEVILLE_NAME_MODE_COPILOT,
+          pi: env.CLAUDEVILLE_NAME_MODE_PI,
+          opencode: env.CLAUDEVILLE_NAME_MODE_OPENCODE,
+          hermes: env.CLAUDEVILLE_NAME_MODE_HERMES,
         };
 
         const modes: Record<string, string> = {};

--- a/shared/cost.test.ts
+++ b/shared/cost.test.ts
@@ -11,11 +11,16 @@ describe('shared cost utilities', () => {
     });
   });
 
-  it('estimates cost for known models and falls back to sonnet', () => {
+  it('estimates cost for known Claude models and unknown Claude aliases', () => {
     expect(estimateCost('claude-opus-4-6', { input: 1_000_000, output: 500_000 })).toBe(52.5);
     expect(estimateCost('claude-sonnet-4-5', { input: 1_000_000, output: 1_000_000 })).toBe(18);
     expect(estimateCost('claude-haiku-4-5', { input: 1_000_000, output: 1_000_000 })).toBe(4.8);
-    expect(estimateCost('unknown-model', { input: 1_000_000, output: 1_000_000 })).toBe(18);
+    expect(estimateCost('claude-new-model', { input: 1_000_000, output: 1_000_000 })).toBe(18);
+  });
+
+  it('does not apply Claude pricing to non-Claude models without explicit rates', () => {
+    expect(estimateCost('gpt-4', { input: 1_000_000, output: 1_000_000 })).toBe(0);
+    expect(estimateCost('nano-gpt/moonshotai/kimi-k2.6:thinking', { input: 1_000_000, output: 1_000_000 })).toBe(0);
   });
 
   it('treats missing or partial token counts as zero', () => {

--- a/shared/cost.ts
+++ b/shared/cost.ts
@@ -14,7 +14,8 @@ export const CLAUDE_RATE_TABLE = {
 
 export function estimateCost(model: string, tokens: { input?: number; output?: number } | null): number {
   const rate = (CLAUDE_RATE_TABLE as Record<string, { input: number; output: number }>)[model]
-    ?? CLAUDE_RATE_TABLE['claude-sonnet-4-5'];
+    ?? (model?.startsWith('claude-') ? CLAUDE_RATE_TABLE['claude-sonnet-4-5'] : null);
+  if (!rate) return 0;
   const input  = Number(tokens?.input  ?? 0);
   const output = Number(tokens?.output ?? 0);
   return (input * rate.input + output * rate.output) / 1000000;

--- a/widget/ClaudeVilleWidget.app/Contents/Resources/node_path
+++ b/widget/ClaudeVilleWidget.app/Contents/Resources/node_path
@@ -1,1 +1,1 @@
-/Users/openclaw/.vite-plus/0.1.15/bin/vp
+node

--- a/widget/ClaudeVilleWidget.app/Contents/Resources/project_path
+++ b/widget/ClaudeVilleWidget.app/Contents/Resources/project_path
@@ -1,1 +1,1 @@
-/Users/openclaw/Github/claude-ville
+__CLAUDEVILLE_PROJECT_PATH__

--- a/widget/Sources/main.swift
+++ b/widget/Sources/main.swift
@@ -354,7 +354,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func readProjectPath() -> String? {
         guard let resURL = Bundle.main.resourceURL else { return nil }
         let f = resURL.appendingPathComponent("project_path")
-        return try? String(contentsOf: f, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let p = try? String(contentsOf: f, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines) else { return nil }
+        if p.isEmpty { return nil }
+        return FileManager.default.fileExists(atPath: p) ? p : nil
     }
 
     // MARK: - Hub URL Resolution


### PR DESCRIPTION
## Summary
- Add async OpenCode adapter for OPENCODE_DATA_DIR or ~/.local/share/opencode storage/session and storage/message JSON files.
- Add async Hermes adapter for HERMES_DIR or ~/.hermes session metadata plus JSONL transcripts.
- Register both adapters and extend registry fixtures so aggregation and watch paths cover the new providers.

## Validation
- npm run typecheck
- npm run lint
- npm run test