### PR TITLE
🔒 [security] Fix insecure default CORS allowed origin

### DIFF
--- a/shared/http-utils.test.ts
+++ b/shared/http-utils.test.ts
@@ -25,9 +25,10 @@ describe('shared HTTP utilities', () => {
     const res = makeResponse();
 
     httpUtils.setCorsHeaders(res);
-    expect(res.setHeader).toHaveBeenNthCalledWith(1, 'Access-Control-Allow-Origin', 'null');
-    expect(res.setHeader).toHaveBeenNthCalledWith(2, 'Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    expect(res.setHeader).toHaveBeenNthCalledWith(3, 'Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    // When no ALLOWED_ORIGIN is set, Access-Control-Allow-Origin should NOT be set
+    expect(res.setHeader).not.toHaveBeenCalledWith('Access-Control-Allow-Origin', expect.any(String));
+    expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Headers', 'Content-Type, Authorization');
 
     httpUtils.sendJson(res, 201, { ok: true });
     expect(res.writeHead).toHaveBeenCalledWith(201, { 'Content-Type': 'application/json; charset=utf-8' });

--- a/shared/http-utils.ts
+++ b/shared/http-utils.ts
@@ -13,22 +13,23 @@ type IncomingMessage = http.IncomingMessage;
 /**
  * CORS origin is restricted by default to prevent unauthorized cross-origin requests.
  * Set ALLOWED_ORIGIN env var to permit specific origins (e.g., http://localhost:3000).
- * In development without ALLOWED_ORIGIN, defaults to restrictive 'null' origin handling.
+ * In development without ALLOWED_ORIGIN, we do not send the header to restrict to same-origin.
  */
-function getAllowedOrigin(): string {
+function getAllowedOrigin(): string | undefined {
   // Explicitly configured origin takes priority
   if (process.env.ALLOWED_ORIGIN) {
     return process.env.ALLOWED_ORIGIN;
   }
-  // In development without explicit config, restrict to same-origin
-  // The '*' wildcard is only appropriate for public APIs without auth
-  return 'null';
+  // If not configured, we do not permit cross-origin access by default.
+  return undefined;
 }
 
 /** Set CORS headers with configurable origin restriction. */
 function setCorsHeaders(res: ServerResponse) {
   const origin = getAllowedOrigin();
-  res.setHeader('Access-Control-Allow-Origin', origin);
+  if (origin) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+  }
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
   // Do not expose credentials in cross-origin requests without explicit auth


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is an insecure default value for the `Access-Control-Allow-Origin` CORS header.
⚠️ **Risk:** The previous fallback for allowed origin was `'null'`, which is exploitable via a sandboxed iframe. This could allow malicious scripts in a sandboxed iframe to perform cross-origin requests that should have been restricted.
🛡️ **Solution:** The fix removes the `'null'` fallback. Now, if no `ALLOWED_ORIGIN` is explicitly configured in the environment, the `Access-Control-Allow-Origin` header is simply not sent. This relies on the browser's default Same-Origin Policy (SOP), which is a much safer and more robust default. Existing unit tests have been updated to reflect this change and were verified manually.

---
*PR created automatically by Jules for task [2912585595205303859](https://jules.google.com/task/2912585595205303859) started by @deadronos*