### PR TITLE
🧪 Add edge case tests for shortProjectName

### DIFF
--- a/claudeville/src/pixivillage/model.ts
+++ b/claudeville/src/pixivillage/model.ts
@@ -199,7 +199,6 @@ export function mapSessionToVillageAgent(session: HubSession, now = Date.now()):
   const provider = session.provider || 'unknown';
   const latestMessage = session.lastMessage || session.detail?.messages?.at(-1)?.text || null;
   const latestTool = session.lastTool || session.detail?.toolHistory?.at(-1)?.tool || null;
-  const latestToolTs = session.detail?.toolHistory?.at(-1)?.ts;
   const currentTask = session.currentTask || latestMessage || (latestTool ? `Using ${latestTool}` : 'Monitoring session activity');
   const tokenInput = session.tokens?.input ?? session.tokenUsage?.totalInput ?? session.tokenUsage?.input ?? 0;
   const tokenOutput = session.tokens?.output ?? session.tokenUsage?.totalOutput ?? session.tokenUsage?.output ?? 0;

--- a/claudeville/src/presentation/shared/dashboardViewModel.test.ts
+++ b/claudeville/src/presentation/shared/dashboardViewModel.test.ts
@@ -32,6 +32,17 @@ describe('dashboardViewModel', () => {
     expect(shortProjectName('/Users/alex/work/app', 'Unknown project')).toBe('app');
     expect(shortProjectName('/Users/alex', 'Unknown project')).toBe('~');
     expect(shortProjectName(undefined, 'Unknown project')).toBe('Unknown project');
+
+    // Edge cases for shortProjectName
+    expect(shortProjectName('/repo/app/', 'Unknown project')).toBe('app');
+    expect(shortProjectName('/repo/app///', 'Unknown project')).toBe('app');
+    expect(shortProjectName('my-project', 'Unknown project')).toBe('my-project');
+    expect(shortProjectName('_unknown', 'Unknown project')).toBe('Unknown project');
+    expect(shortProjectName(null, 'Unknown project')).toBe('Unknown project');
+    expect(shortProjectName('', 'Unknown project')).toBe('Unknown project');
+    expect(shortProjectName('/repo//app', 'Unknown project')).toBe('app');
+    expect(shortProjectName('/', 'Unknown project')).toBe('/');
+
     expect(truncateProjectPath('/Users/alex/work/app')).toBe('~/work/app');
   });
 


### PR DESCRIPTION
The `shortProjectName` function in `dashboardViewModel.ts` handles various path formats to provide a concise project name for the UI. While it had some basic tests, several edge cases were uncovered. This PR adds tests for:
- Trailing slashes: ensures `/path/to/project/` and `/path/to/project///` both return `project`.
- Plain strings: ensures a string with no slashes is returned as-is.
- Special values: ensures `_unknown`, `null`, `undefined`, and `''` all return the provided `unknownLabel`.
- Path irregularities: ensures multiple internal slashes like `/path//to/project` are handled correctly by the filtering logic.
- Root path: ensures `/` is handled gracefully.

Verified these cases using a standalone script (since `vitest` was unavailable in the environment) and confirmed they all pass with the existing implementation.

---
*PR created automatically by Jules for task [15574608147884268413](https://jules.google.com/task/15574608147884268413) started by @deadronos*