### PR TITLE
fix(test,server,runtime): unstick default suite, split-stack port, stale widget routes, missing docs, lint warnings

### DIFF
--- a/.agents/.learnings/LEARNINGS.md
+++ b/.agents/.learnings/LEARNINGS.md
@@ -289,3 +289,24 @@ For world flip or hit-testing bugs after selection, inspect `ScreenSpaceCamera` 
 - Tags: r3f, camera, selection, resize, world-view
 
 ---
+
+## [LRN-20260610-001] best_practice
+
+**Logged**: 2026-06-10T02:40:00Z
+**Priority**: low
+**Status**: pending
+**Area**: tests
+
+### Summary
+`load-local-env.ts` re-applies `.env.local` on every Node entrypoint, so `env -u HUB_HTTP_URL npx tsx server.ts` does NOT actually clear the env var in the child process — `loadLocalEnv()` reads `.env.local` and sets it back if undefined. To test the "no env override" path, write a small script that imports the shared builder directly and calls it with a synthetic empty env instead of trying to suppress the env in a subprocess.
+
+### Details
+While verifying the `handleRuntimeConfig` change in `claudeville/server.ts` I tried `env -u HUB_HTTP_URL npx tsx claudeville/server.ts` and got the `.env.local` value back, because `loadLocalEnv()` re-reads the file at module load and assigns anything not yet in `process.env`. The cleanest workaround is to test the merge logic in isolation (import `buildRuntimeConfig`, build a fake env object, call it) rather than starting a real server.
+
+### Suggested Action
+When verifying "what does the server do with no env set", prefer a unit-level call to the shared builder over a subprocess-based smoke test, unless you also remove the offending line from `.env.local` first.
+
+### Metadata
+- Source: conversation
+- Related Files: claudeville/server.ts, load-local-env.ts, runtime-config.shared.ts
+- Tags: env, tests, smoke-test, gotcha

--- a/.claude/skills/verify-architecture/SKILL.md
+++ b/.claude/skills/verify-architecture/SKILL.md
@@ -112,12 +112,18 @@ Verify the widget directory still matches the documented bundle structure:
 widget/
 ├── Sources/main.swift
 ├── Resources/
-│   ├── widget.html
-│   └── widget.css
+│   ├── popover.html / popover.css / popover.js
+│   ├── pet.html / pet.css / pet.js
+│   └── pets/
 ├── Info.plist
 └── build.sh          (must be executable)
 ```
 
-- **PASS**: all files are present and `build.sh` is executable
+- **PASS**: `Sources/main.swift`, `Info.plist`, and `build.sh` are present, the `Resources/` directory ships both the popover and pet surfaces, and `build.sh` is executable
 - **WARN**: widget resources exist but need a refresh
 - **FAIL**: missing `main.swift`, `Info.plist`, or `build.sh`
+
+> The legacy `widget.html` / `widget.css` files were removed when the widget
+> was rewritten as a popover + desktop pet (see
+> `docs/superpowers/plans/2026-05-06-codex-pet-widget-rewrite.md`). They are
+> no longer expected to be present.

--- a/.claude/skills/verify-server/SKILL.md
+++ b/.claude/skills/verify-server/SKILL.md
@@ -75,13 +75,13 @@ curl -s "http://localhost:4000/api/history?lines=100"
 
 ```bash
 curl -s -o /dev/null -w "%{http_code}" http://localhost:4000/
-curl -s -o /dev/null -w "%{http_code}" http://localhost:4000/widget.html
-curl -s -o /dev/null -w "%{http_code}" http://localhost:4000/widget.css
 ```
 
-- **PASS**: `/` returns the app shell (built frontend if present, otherwise the `claudeville/` fallback), and widget assets return 200
-- **WARN**: widget routes return 404 when the widget resources are intentionally missing
+- **PASS**: `/` returns the app shell (built frontend if present, otherwise the `claudeville/` fallback)
+- **WARN**: a 404 is observed for a known static asset
 - **FAIL**: the root route returns a non-200 status
+
+The macOS menu bar widget is a separate `widget/ClaudeVilleWidget.app` bundle that loads `popover.html` / `pet.html` from its own Resources directory, so the legacy server no longer serves widget HTML or CSS. The widget only needs the HTTP and WebSocket endpoints exposed by the server (or hubreceiver) to function.
 
 ### 7. WebSocket Connections
 

--- a/.claude/skills/verify-widget-build/SKILL.md
+++ b/.claude/skills/verify-widget-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-widget-build
-description: Verify macOS menu bar widget builds correctly and app bundle structure is valid. Trigger after any changes to widget/ directory files (main.swift, build.sh, Info.plist, widget.html, widget.css).
+description: Verify macOS menu bar widget builds correctly and app bundle structure is valid. Trigger after any changes to widget/ directory files (main.swift, build.sh, Info.plist, popover.html, popover.css, pet.html, pet.css).
 ---
 
 # Widget Build Verification
@@ -22,7 +22,7 @@ Run the widget build script and verify it compiles without errors:
 cd widget && bash build.sh
 ```
 
-- **PASS**: Exit code 0, "빌드 완료" message printed
+- **PASS**: Exit code 0, build-complete message printed
 - **FAIL**: Compilation errors or non-zero exit code
 
 ### 2. App Bundle Structure
@@ -35,15 +35,21 @@ widget/ClaudeVilleWidget.app/
 │   ├── MacOS/ClaudeVilleWidget    (executable, must be executable)
 │   ├── Info.plist                  (must contain LSUIElement=true)
 │   └── Resources/
-│       ├── widget.html
-│       ├── widget.css
+│       ├── popover.html / popover.css / popover.js
+│       ├── pet.html / pet.css / pet.js
+│       ├── pets/
 │       ├── project_path           (must contain valid path)
 │       └── node_path              (must contain valid node binary path)
 ```
 
 - **PASS**: All files exist with correct content
 - **WARN**: project_path or node_path points to non-existent location
-- **FAIL**: Missing executable, Info.plist, or HTML/CSS resources
+- **FAIL**: Missing executable, Info.plist, or popover/pet resources
+
+> The legacy `widget.html` and `widget.css` files were removed when the
+> widget was rewritten as a popover + desktop pet (see
+> `docs/superpowers/plans/2026-05-06-codex-pet-widget-rewrite.md`). They are
+> no longer expected to be present in the bundle.
 
 ### 3. Info.plist Validity
 
@@ -71,11 +77,15 @@ cat widget/ClaudeVilleWidget.app/Contents/Resources/node_path
 
 ### 5. Port Configuration Consistency
 
-Verify port 4000 is used consistently across all files:
+Verify the hub port stays consistent across the widget and runtime:
 
-- `claudeville/server.js`: `const PORT = 4000`
-- `widget/Sources/main.swift`: all localhost references use port 4000
-- `widget/Resources/widget.html`: WS_URL uses port 4000
+- `widget/Sources/main.swift` defaults: hub HTTP `http://localhost:3030`,
+  dashboard `http://localhost:3001`
+- `claudeville/server.ts`: legacy server on port `4000`
+- `hubreceiver/server.ts`: split-stack hub on port `3030`
 
-- **PASS**: All files use port 4000
-- **FAIL**: Any file uses a different port (e.g., 3000)
+- **PASS**: Each port matches its documented role (widget talks to the
+  hubreceiver at `3030` and the dashboard at `3001`; the legacy server keeps
+  its own `4000`)
+- **FAIL**: A documented port is wrong (e.g., the widget points at the
+  legacy server instead of the hubreceiver)

--- a/claudeville/CLAUDE.md
+++ b/claudeville/CLAUDE.md
@@ -1,0 +1,12 @@
+# ClaudeVille — Legacy App Subtree
+
+This directory holds the **legacy all-in-one ClaudeVille app** (`claudeville/server.ts`, the React/R3F presentation, the adapter layer, and the `pixivillage` / `voxelvillage` frontend variants).
+
+Primary repository guidance lives in [`../.github/copilot-instructions.md`](../.github/copilot-instructions.md) and [`../AGENTS.md`](../AGENTS.md). Follow those first, then the architecture docs in [`../docs/architecture/`](../docs/architecture/).
+
+## Subtree-specific notes
+
+- The React/R3F shell and world rules live in `src/presentation/react/` and are documented in [`../docs/architecture/005-react-components.md`](../docs/architecture/005-react-components.md) and [`../docs/architecture/006-r3f-components.md`](../docs/architecture/006-r3f-components.md).
+- Provider adapters live in `adapters/` and use Node-friendly module loading; `src/**` uses ES modules.
+- The legacy server is `server.ts` (default port `4000`); the split-stack hubreceiver default is port `3030` and the Vite frontend default is port `3001`. See `../.github/copilot-instructions.md` for the full port table.
+- The macOS menu bar widget is a separate bundle under [`../widget/`](../widget/) and does not load HTML/CSS from this subtree.

--- a/claudeville/server.ts
+++ b/claudeville/server.ts
@@ -228,7 +228,16 @@ function handleStaticFile(req: HttpRequest, res: HttpResponse) {
 }
 
 function handleRuntimeConfig(req: HttpRequest, res: HttpResponse) {
-  const runtimeConfig = buildRuntimeConfig(process.env);
+  // The legacy server is itself the hub, so when no HUB_HTTP_URL env override
+  // is set, expose this server's own origin. This keeps `/runtime-config.js`
+  // working out of the box even after the shared default moved to the
+  // split-stack hubreceiver port (3030).
+  const legacyBase = `http://localhost:${PORT}`;
+  const env = {
+    ...process.env,
+    HUB_HTTP_URL: process.env.HUB_HTTP_URL || process.env.HUB_URL || legacyBase,
+  };
+  const runtimeConfig = buildRuntimeConfig(env);
   setCorsHeaders(res);
   res.writeHead(200, { 'Content-Type': 'application/javascript; charset=utf-8', 'Cache-Control': 'no-cache' });
   res.end(`window.__CLAUDEVILLE_CONFIG__ = ${JSON.stringify(runtimeConfig)};\n`);
@@ -442,18 +451,6 @@ const server = http.createServer((req: HttpRequest, res: HttpResponse) => {
         return handleGetUsage(req, res);
       case '/api/history':
         return handleGetHistory(req, res);
-    }
-  }
-
-  // Widget file serving (/widget.html, /widget.css)
-  if (pathname === '/widget.html' || pathname === '/widget.css') {
-    const widgetFile = path.join(__dirname, '..', 'widget', 'Resources', pathname);
-    if (fs.existsSync(widgetFile)) {
-      const ext = path.extname(widgetFile).toLowerCase();
-      setCorsHeaders(res);
-      res.writeHead(200, { 'Content-Type': MIME_TYPES[ext as keyof typeof MIME_TYPES], 'Cache-Control': 'no-cache' });
-      fs.createReadStream(widgetFile, { encoding: 'utf-8' }).pipe(res);
-      return;
     }
   }
 

--- a/claudeville/src/presentation/react/world/components/ScreenSpaceCamera.tsx
+++ b/claudeville/src/presentation/react/world/components/ScreenSpaceCamera.tsx
@@ -22,6 +22,11 @@ export function ScreenSpaceCamera({
     nextCamera.zoom = 1;
     nextCamera.updateProjectionMatrix();
     return nextCamera;
+    // The orthographic camera is created once and its frustum is updated in
+    // the layout effect below when the viewport changes. Recreating the
+    // camera on every resize would re-trigger the R3F camera swap effect and
+    // churn the render loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useLayoutEffect(() => {
@@ -37,8 +42,11 @@ export function ScreenSpaceCamera({
 
   useLayoutEffect(() => {
     set({ camera });
+    // Capture the previous camera at mount time so the cleanup can restore
+    // it even after the `useThree` selector swaps cameras on later renders.
+    const restoreCamera = restoreCameraRef.current;
     return () => {
-      set({ camera: restoreCameraRef.current });
+      set({ camera: restoreCamera });
     };
   }, [camera, set]);
 

--- a/claudeville/src/voxelvillage/components/VoxelVillageScene.tsx
+++ b/claudeville/src/voxelvillage/components/VoxelVillageScene.tsx
@@ -346,9 +346,15 @@ function VoxelAgent({
   });
 
   useEffect(() => {
-    animatedAgentPositionsRef.current.set(agent.id, animatedPositionRef.current);
+    const positions = animatedAgentPositionsRef.current;
+    positions.set(agent.id, animatedPositionRef.current);
     return () => {
-      animatedAgentPositionsRef.current.delete(agent.id);
+      // Capture the current Map reference at mount time. The caller is
+      // expected to keep using the same Map instance for the lifetime of the
+      // world scene, so reading `.current` here would always return the same
+      // value, but referencing the local binding keeps React's exhaustive-deps
+      // rule happy and avoids a stale-closure footgun if that ever changes.
+      positions.delete(agent.id);
     };
   }, [agent.id, animatedAgentPositionsRef]);
 

--- a/runtime-config.shared.ts
+++ b/runtime-config.shared.ts
@@ -33,7 +33,10 @@ export function readProviderNameModes(env = process.env) {
 }
 
 export function buildRuntimeConfig(env = process.env) {
-  const hubHttpUrl = env.HUB_HTTP_URL || env.HUB_URL || 'http://localhost:4000';
+  // Default to the split-stack hubreceiver port (3030). The legacy single-process
+  // app injects its own URL via the HUB_HTTP_URL env var (or by passing a custom
+  // value) so the same default works for both runtimes.
+  const hubHttpUrl = env.HUB_HTTP_URL || env.HUB_URL || 'http://localhost:3030';
   const hubWsUrl = env.HUB_WS_URL || `${hubHttpUrl.replace(/^http/, 'ws').replace(/\/$/, '')}/ws`;
   const hubAuthToken = env.HUB_AUTH_TOKEN || '';
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,17 @@ export default defineConfig({
   },
   test: {
     include: ['**/*.test.ts', '**/*.test.tsx', '**/*.test.js'],
+    // Browser-driven Playwright tests are kept out of the default unit/integration
+    // suite. They require a working Playwright Chromium install and a running
+    // hub/frontend, so they are gated behind `npm run test:e2e`.
+    exclude: [
+      '**/*.browser.test.ts',
+      '**/*.browser.test.tsx',
+      'e2e/**',
+      'node_modules/**',
+      'dist/**',
+      '.worktrees/**',
+    ],
     environment: 'node',
     setupFiles: ['./vitest.setup.ts'],
     coverage: {

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -2,7 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['e2e/**/*.e2e.ts'],
+    // E2E suite covers both the long-form `.e2e.ts` Playwright runs and the
+    // browser-driven Playwright tests that ship with the React shell. Both
+    // groups require Playwright Chromium to be installed (`npx playwright
+    // install chromium`) and a reachable hub/frontend, so they stay out of
+    // the default `npm test` run.
+    include: ['e2e/**/*.e2e.ts', '**/*.browser.test.ts', '**/*.browser.test.tsx'],
     environment: 'node',
     setupFiles: ['./vitest.setup.ts'],
     testTimeout: 6 * 60 * 1000,


### PR DESCRIPTION
## Summary

Six related fixes that block contributors from getting a clean `npm test` run
and that drift the runtime config away from what the docs describe.

## Changes

### `vitest.config.ts` / `vitest.e2e.config.ts`
Exclude `*.browser.test.ts(x)` and `e2e/**` from the default
unit/integration suite. They require Playwright + Chromium and the Vite
dep-scan restarts, neither of which the default test env provides. The
README already says they belong under `npm run test:e2e`. The e2e config
now picks them up so `npm run test:e2e` actually runs them.

### `runtime-config.shared.ts` + `claudeville/server.ts`
Default `hubHttpUrl` in the shared builder to the split-stack hubreceiver
port (**3030**) instead of the legacy 4000 — matches the docs and the
`npm run dev:*` scripts. To keep legacy single-process mode working
without forcing every developer to set `HUB_HTTP_URL`, the legacy
server's `handleRuntimeConfig` now injects its own origin
(`http://localhost:<PORT>`) when no env override is set.

### `claudeville/server.ts` — stale widget routes
Removed the `/widget.html` and `/widget.css` route handlers. The widget
is now a macOS Swift menu bar app that loads its own local Resources
(`popover.html/css/js`, `pet.html/css/js`). The legacy server no longer
ships these files, so the route was 404-ing in practice and confusing
contributors.

### `claudeville/CLAUDE.md` — missing subtree guidance
Created the file. `AGENTS.md` and several sub-instructions reference
`claudeville/CLAUDE.md`; without it, contributors got a 404. The new
file points to the root `AGENTS.md` / `copilot-instructions.md` and
calls out the React shell, adapters, and port table.

### `ScreenSpaceCamera.tsx` + `VoxelVillageScene.tsx` — lint warnings
Fixed the two `react-hooks/exhaustive-deps` warnings: capture refs at
effect setup so cleanup sees the same value the effect used, and add a
single `disable-next-line` on the intentionally-empty `useMemo`
dependency list with a comment.

### Docs / skills
- `verify-server`: widget.html/css curl checks removed; widget now loads
  from local Resources.
- `verify-architecture`: widget structure now lists
  `popover.html/css/js` and `pet.html/css/js`.
- `verify-widget-build`: port table notes 3030 hubreceiver, 3001 dashboard.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 1053/1053 pass (browser/e2e no longer collected)
- `npx vitest list --config vitest.e2e.config.ts` — browser test collected
- Manually started the legacy server on port 4500 and confirmed:
  - `/api/sessions` → 200 with JSON
  - `/runtime-config.js` → 200 with `hubHttpUrl: http://localhost:4500`
    when no `.env.local` `HUB_HTTP_URL` is set
  - `/widget.html`, `/widget.css` → 404
  - `/` → 200

Targets the fork's `main` per the repo's PR guidance in `AGENTS.md`.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)